### PR TITLE
Patch: Misc fixes for Data module

### DIFF
--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/Identity.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/Identity.kt
@@ -89,7 +89,7 @@ data class SimpleIdentity(
      * {AREA}.{SERVICE}.{AGENT}.{ENV}
      * signup.alerts.job.qat
      */
-    override val fullname: String = "$name.${agent.name.toLowerCase()}.${env.toLowerCase()}"
+    override val fullname: String = "$name.${agent.name.toLowerCase()}.${env.toLowerCase()}.${version.replace(".", "_")}"
 
     /**
      * The id contains the instance name

--- a/src/lib/kotlin/slatekit-db/src/main/kotlin/slatekit/db/DbUtils.kt
+++ b/src/lib/kotlin/slatekit-db/src/main/kotlin/slatekit/db/DbUtils.kt
@@ -166,7 +166,7 @@ object DbUtils {
                             DataType.DTLong -> stmt.setLong(pos, arg.value as Long)
                             DataType.DTFloat -> stmt.setFloat(pos, arg.value as Float)
                             DataType.DTDouble -> stmt.setDouble(pos, arg.value as Double)
-                            DataType.DTEnum -> stmt.setInt(pos, (arg.value as EnumLike).value)
+                            DataType.DTEnum -> stmt.setInt(pos, toEnumValue(arg.value!!))
                             DataType.DTLocalDate -> stmt.setDate(pos, java.sql.Date.valueOf((arg.value as LocalDate).toJava8LocalDate()))
                             DataType.DTLocalTime -> stmt.setTime(pos, java.sql.Time.valueOf((arg.value as LocalTime).toJava8LocalTime()))
                             DataType.DTLocalDateTime -> stmt.setTimestamp(pos, java.sql.Timestamp.valueOf((arg.value as LocalDateTime).toJava8LocalDateTime()))
@@ -184,6 +184,16 @@ object DbUtils {
             catch(ex:Exception) {
                 error(ex)
             }
+        }
+    }
+
+    fun toEnumValue(value:Any):Int {
+        return when(value) {
+            is Int      -> value
+            is EnumLike -> value.value
+            is Enum<*>  -> value.ordinal
+            is String   -> value.toInt()
+            else        -> value.toString().toInt()
         }
     }
 

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/Entities.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/Entities.kt
@@ -67,7 +67,6 @@ open class Entities(
     val logs: Logs = LogsDefault,
     val namer: Namer? = null
 ) {
-
     private var info = ListMap<String, EntityContext>(listOf())
     val mappers = mutableMapOf<String, EntityMapper<*, *>>()
     val logger = logs.getLogger("db")

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/mapper/EntityMapper.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/mapper/EntityMapper.kt
@@ -48,7 +48,7 @@ open class EntityMapper<TId, T>(val model: Model,
      * Gets the data type of the field
      */
     override fun datatype(field:String): DataType {
-        return when(val mappedField =model.lookup[field]){
+        return when(val mappedField = model.lookup[field]){
             null -> throw Exception("Field not mapped! model=${model.name}, field=$field")
             else -> mappedField.dataTpe
         }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/IdentityTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/IdentityTests.kt
@@ -1,0 +1,62 @@
+/**
+<slate_header>
+url: www.slatekit.com
+git: www.github.com/code-helix/slatekit
+org: www.codehelix.co
+author: Kishore Reddy
+copyright: 2016 CodeHelix Solutions Inc.
+license: refer to website and/or github
+about: A Kotlin utility library, tool-kit and server backend.
+mantra: Simplicity above all else
+</slate_header>
+ */
+package test.common
+
+import org.junit.Assert
+import slatekit.common.envs.*
+
+import org.junit.Test
+import slatekit.common.Agent
+import slatekit.common.Identity
+import slatekit.common.SimpleIdentity
+import slatekit.common.ids.ULIDs
+
+
+class IdentityTests {
+
+    @Test fun can_build_via_helper() {
+        val id1 = Identity.app("signup", "alerts", EnvMode.Qat)
+        Assert.assertEquals( "signup", id1.area )
+        Assert.assertEquals( "alerts", id1.service )
+        Assert.assertEquals( Agent.App, id1.agent )
+        Assert.assertEquals( EnvMode.Qat.name, id1.env )
+        Assert.assertEquals( "LATEST", id1.version )
+        Assert.assertEquals( "signup.alerts", id1.name )
+        Assert.assertEquals( "signup.alerts.app.qat.LATEST", id1.fullname )
+    }
+
+
+    @Test fun can_create_manually() {
+        val id1 = SimpleIdentity("signup", "alerts", Agent.App, EnvMode.Qat.name, version = "1.2")
+        Assert.assertEquals( "signup", id1.area )
+        Assert.assertEquals( "alerts", id1.service )
+        Assert.assertEquals( Agent.App, id1.agent )
+        Assert.assertEquals( EnvMode.Qat.name, id1.env )
+        Assert.assertEquals( "1.2", id1.version )
+        Assert.assertEquals( "signup.alerts", id1.name )
+        Assert.assertEquals( "signup.alerts.app.qat.1_2", id1.fullname )
+    }
+
+
+    @Test fun can_create_with_id() {
+        val id = ULIDs.create()
+        val id1 = SimpleIdentity("signup", "alerts", Agent.App, EnvMode.Qat.name, version = "1.2", instance= id.value)
+        Assert.assertEquals( "signup", id1.area )
+        Assert.assertEquals( "alerts", id1.service )
+        Assert.assertEquals( Agent.App, id1.agent )
+        Assert.assertEquals( EnvMode.Qat.name, id1.env )
+        Assert.assertEquals( "1.2", id1.version )
+        Assert.assertEquals( "signup.alerts", id1.name )
+        Assert.assertEquals( "signup.alerts.app.qat.1_2.${id.value}", id1.id )
+    }
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/ModelTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/ModelTests.kt
@@ -3,10 +3,12 @@ package test.meta
 import org.junit.Assert
 import org.junit.Test
 import slatekit.common.DateTime
+import slatekit.common.data.DataType
 import slatekit.common.ids.UPID
 import slatekit.meta.Reflector
 import slatekit.meta.models.FieldCategory
 import slatekit.meta.models.Model
+import test.entities.SampleEntityImmutable
 import test.setup.*
 import java.util.*
 import kotlin.reflect.KClass
@@ -48,6 +50,22 @@ class ModelTests {
         ensureField(model, "status"    , false, StatusEnum::class )
         ensureField(model, "salary"    , false, Double::class     )
         ensureField(model, "createdAt" , false, DateTime::class   )
+    }
+
+
+    @Test fun can_build_simple_with_sub_objects(){
+        val model = Model.loadSchema(SampleEntityImmutable::class, SampleEntityImmutable::id.name)
+        Assert.assertTrue(model.hasId)
+        Assert.assertTrue(model.any)
+        fun ensure(name:String, storedAs:String, type:DataType, model: Model){
+            Assert.assertTrue(model.lookup[name] != null)
+            Assert.assertEquals(storedAs, model.lookup[name]?.storedName)
+            Assert.assertEquals(type, model.lookup[name]?.dataTpe)
+        }
+        ensure("test_object", "test_object", DataType.DTObject, model)
+        ensure("test_object_state", "test_object_state", DataType.DTString, model)
+        ensure("test_object_country", "test_object_country", DataType.DTInt, model)
+        ensure("test_object_isPOBox", "test_object_isPOBox", DataType.DTBool, model)
     }
 
 


### PR DESCRIPTION
## Overview
Misc fixes for data module + Identity

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
n/a

## Design
1. Fixed handling of Enum to take in integer, Enum<*>, EnumLike
2. Fixed handling of Model schema to properly store lookup for fields of sub-objects
3. Fixed minor name generation for identity

## Notes
n/a

## Pending
n/a

## Tests
Added more tests
