### PR TITLE
Data: Support for installing module + JPA alignment

### DIFF
--- a/src/apps/kotlin/slatekit-samples/build.gradle
+++ b/src/apps/kotlin/slatekit-samples/build.gradle
@@ -5,6 +5,7 @@ buildscript {
     ext.slatekit_version = new File('../version.txt').text
     ext.slatekit_version_beta = new File('../version-beta.txt').text
     ext.ktor_version = '1.1.1'
+    ext.logback_contrib_version = '0.1.5'
 
     repositories {
         jcenter()
@@ -87,6 +88,10 @@ dependencies {
     compile "mysql:mysql-connector-java:5.1.13"
     compile 'com.squareup.okhttp3:okhttp:3.9.0'
     compile 'org.threeten:threetenbp:1.3.8'
+    compile "ch.qos.logback.contrib:logback-jackson:$logback_contrib_version"
+    compile "ch.qos.logback.contrib:logback-json-classic:$logback_contrib_version"
+    compile "com.fasterxml.jackson.core:jackson-databind:2.9.5"
+    compile "org.slf4j:slf4j-api:1.7.25"
 
     // /* <slatekit_local>
     if( slatekitSetupViaBinary ) {
@@ -94,7 +99,7 @@ dependencies {
         implementation "com.slatekit:slatekit-common:$slatekit_version"
         implementation "com.slatekit:slatekit-context:$slatekit_version"
         implementation "com.slatekit:slatekit-app:$slatekit_version"
-        implementation "com.slatekit:slatekit-meta:$slatekit_version_beta"
+        implementation "com.slatekit:slatekit-meta:$slatekit_version"
         implementation "com.slatekit:slatekit-policy:$slatekit_version"
         implementation "com.slatekit:slatekit-serialization:$slatekit_version"
         implementation "com.slatekit:slatekit-tracking:$slatekit_version"
@@ -106,12 +111,12 @@ dependencies {
         implementation "com.slatekit:slatekit-http:$slatekit_version"
         implementation "com.slatekit:slatekit-notifications:$slatekit_version"
         implementation "com.slatekit:slatekit-cli:$slatekit_version"
-        implementation "com.slatekit:slatekit-db:$slatekit_version_beta"
-        implementation "com.slatekit:slatekit-query:$slatekit_version_beta"
-        implementation "com.slatekit:slatekit-entities:$slatekit_version_beta"
-        implementation "com.slatekit:slatekit-orm:$slatekit_version_beta"
-        implementation "com.slatekit:slatekit-integration:$slatekit_version_beta"
-        implementation "com.slatekit:slatekit-server:$slatekit_version_beta"
+        implementation "com.slatekit:slatekit-db:$slatekit_version"
+        implementation "com.slatekit:slatekit-query:$slatekit_version"
+        implementation "com.slatekit:slatekit-data:$slatekit_version"
+        implementation "com.slatekit:slatekit-entities:$slatekit_version"
+        implementation "com.slatekit:slatekit-integration:$slatekit_version"
+        implementation "com.slatekit:slatekit-server:$slatekit_version"
         implementation "com.slatekit:slatekit-connectors-cli:$slatekit_version"
         implementation "com.slatekit:slatekit-connectors-jobs:$slatekit_version"
         implementation "com.slatekit:slatekit-providers-aws:$slatekit_version"
@@ -127,7 +132,6 @@ dependencies {
         implementation project(":slatekit-query")
         implementation project(":slatekit-data")
         implementation project(":slatekit-entities")
-        //implementation project(":slatekit-orm")
         implementation project(":slatekit-meta")
         implementation project(":slatekit-policy")
         implementation project(":slatekit-serialization")

--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/Sampler.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/Sampler.kt
@@ -2,8 +2,8 @@ package slatekit.samples
 
 
 fun main(args: Array<String>) {
-    Samples.app(args)
-//    Samples.cli(args)
+//    Samples.app(args)
+    Samples.cli(args)
 //    Samples.api(args)
 //    Samples.job(arrayOf("-sample=onetime"))
 }

--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/app/App.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/app/App.kt
@@ -2,6 +2,7 @@ package slatekit.samples.app
 
 import slatekit.app.App
 import slatekit.app.AppOptions
+import slatekit.common.DateTimes
 import slatekit.context.Context
 import slatekit.common.args.ArgsSchema
 import slatekit.common.utils.B64Java8
@@ -58,6 +59,9 @@ class App(ctx: Context) : App<Context>(ctx, AppOptions(showWelcome = true)) {
 
 
     override suspend fun exec(): Any? {
+        val logger = ctx.logs.getLogger("app")
+        val values = listOf("a" to 1, "b" to true, "c" to "kotlin", "d" to DateTimes.now())
+        logger.warn("test warn", values)
         println("executing")
         println("Your work should be done here...")
         return OK

--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/cli/App.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/cli/App.kt
@@ -4,9 +4,12 @@ import slatekit.app.App
 import slatekit.app.AppOptions
 import slatekit.context.Context
 import slatekit.common.args.ArgsSchema
+import slatekit.common.conf.Confs
 import slatekit.common.utils.B64Java8
 import slatekit.common.crypto.Encryptor
+import slatekit.common.data.Connections
 import slatekit.common.info.About
+import slatekit.connectors.entities.AppEntContext
 
 
 /**
@@ -66,7 +69,11 @@ class App(ctx: Context) : App<Context>(ctx, AppOptions(showWelcome = false, show
         // samples.cli.greet -greeting="whats up"
         // samples.cli.movies
         // samples.cli.inputs -name="kishore" -isActive=true -age=41 -dept=2 -account=123 -average=2.4 -salary=120000 -date="2019-04-01T11:05:30Z"
-        val cli = CLI(ctx)
+        val dbConfPath = "usr://.slatekit/common/conf/db.conf"
+        val con = Confs.readDbCon(App::class.java, dbConfPath)!!
+        val cons = Connections.of(con)
+        val entCtx = AppEntContext.fromContext(ctx, cons = cons)
+        val cli = CLI(entCtx)
         return cli.execute()
     }
 

--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/cli/CLI.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/cli/CLI.kt
@@ -4,16 +4,24 @@ import slatekit.apis.*
 import slatekit.apis.routes.Api
 import slatekit.apis.support.Authenticator
 import slatekit.cli.CliSettings
-import slatekit.context.Context
 import slatekit.common.types.Content
 import slatekit.common.info.ApiKey
 import slatekit.common.types.ContentType
 import slatekit.connectors.cli.CliApi
+import slatekit.connectors.entities.AppEntContext
+import slatekit.entities.EntityId
+import slatekit.entities.EntityLongId
+import slatekit.entities.EntityService
 import slatekit.results.Try
 import slatekit.serialization.Serialization
+import slatekit.integration.apis.*
+import slatekit.integration.mods.*
+import slatekit.migrations.MigrationService
+import slatekit.migrations.MigrationSettings
 import slatekit.samples.common.apis.SampleAPI
+import slatekit.samples.common.models.Movie
 
-class CLI(val ctx: Context) {
+class CLI(val ctx: AppEntContext) {
 
     /**
      * executes the CLI integrated with the API module
@@ -29,7 +37,14 @@ class CLI(val ctx: Context) {
         val auth = Authenticator(keys)
 
         // 3. Load all the Slate Kit Universal APIs
-        val apis = apis()
+        ctx.ent.register<Long, Movie>(EntityLongId(), "movie") { repo -> EntityService( repo ) }
+        ctx.ent.register<Long, Mod>(EntityLongId(), "mod") { repo -> ModService(ctx.ent, repo)}
+        val modSvc = ctx.ent.getServiceByType(Mod::class) as ModService
+        val migSvc = MigrationService(ctx.ent, ctx.ent.dbs, MigrationSettings(true, true), ctx.dirs)
+        val modCtx = ModuleContext(modSvc, migSvc )
+        val modApi = ModuleApi(modCtx, ctx)
+        modApi.register(MovieModule(ctx, modCtx))
+        val apis = apis(modApi)
 
         // 4. Makes the APIs accessible on the CLI runner
         val cli = CliApi(
@@ -49,9 +64,11 @@ class CLI(val ctx: Context) {
     }
 
 
-    fun apis(): List<Api> {
+    fun apis(modApi:ModuleApi): List<Api> {
         return listOf(
-                Api(klass = SampleAPI::class, singleton = SampleAPI(ctx), setup = SetupType.Annotated)
+                Api(klass = SampleAPI::class, singleton = SampleAPI(ctx), setup = SetupType.Annotated),
+                Api(klass = EntitiesApi::class, singleton = EntitiesApi(ctx), setup = SetupType.Annotated),
+                Api(klass = ModuleApi::class, singleton = modApi, setup = SetupType.Annotated)
         )
     }
 
@@ -63,5 +80,20 @@ class CLI(val ctx: Context) {
         val pretty = body.toString(4)
         val content = Content.text(pretty)
         return content
+    }
+
+    class MovieModule(ctx:AppEntContext, mod:ModuleContext) : Module(ctx, mod) {
+        override val info: ModuleInfo = ModuleInfo(
+                name = Movie::class.qualifiedName!!,
+                desc = "Supports user registration",
+                version = "1.0",
+                isInstalled = false,
+                isEnabled = true,
+                isDbDependent = true,
+                totalModels = 1,
+                source = Movie::class.qualifiedName!!,
+                dependencies = "none",
+                models = listOf<String>(Movie::class.qualifiedName!!)
+        )
     }
 }

--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/data/MovieMapper1.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/data/MovieMapper1.kt
@@ -41,6 +41,20 @@ class MovieMapper1(val encoders:Encoders<Long, Movie>) : Mapper<Long, Movie> {
                 Value(Movie::released.name , DataType.DTDateTime, encoders.dateTimes.encode(model.released))
         )
     }
+
+    override fun datatype(field: String): DataType {
+        return when(field) {
+            Movie::uuid.name     -> DataType.DTUUID
+            Movie::title.name    -> DataType.DTString
+            Movie::category.name -> DataType.DTString
+            Movie::playing.name  -> DataType.DTBool
+            Movie::delivery.name -> DataType.DTInt
+            Movie::cost.name     -> DataType.DTInt
+            Movie::rating.name   -> DataType.DTDouble
+            Movie::released.name -> DataType.DTDateTime
+            else -> DataType.DTString
+        }
+    }
 }
 
 

--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/data/MovieMapper2.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/data/MovieMapper2.kt
@@ -4,6 +4,7 @@ import slatekit.data.core.LongId
 import slatekit.data.core.Meta
 import slatekit.data.core.Table
 import slatekit.entities.mapper.EntityMapper
+import slatekit.entities.mapper.EntitySettings
 import slatekit.meta.models.Model
 import slatekit.samples.common.models.Movie
 
@@ -30,4 +31,4 @@ object MovieMapper2 : EntityMapper<Long, Movie>(
         model = movieModel,
         meta = Meta(LongId { m -> m.id }, Table("movie")),
         idClass = Long::class,
-        enClass = Movie::class)
+        enClass = Movie::class, settings = EntitySettings())

--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/data/MovieMapper3.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/data/MovieMapper3.kt
@@ -14,7 +14,7 @@ import slatekit.samples.common.models.Movie
  * Cons: Less performant than manual
  */
 object MovieMapper3 : EntityMapper<Long, Movie>(
-        model = Model.loadSchema(Movie::class),
+        model = Model.load(Movie::class),
         meta = Meta(LongId { m -> m.id }, Table("movie")),
         idClass = Long::class,
         enClass = Movie::class, settings = EntitySettings(true))

--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/data/MovieMapper3.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/data/MovieMapper3.kt
@@ -4,6 +4,7 @@ import slatekit.data.core.LongId
 import slatekit.data.core.Meta
 import slatekit.data.core.Table
 import slatekit.entities.mapper.EntityMapper
+import slatekit.entities.mapper.EntitySettings
 import slatekit.meta.models.Model
 import slatekit.samples.common.models.Movie
 
@@ -16,4 +17,4 @@ object MovieMapper3 : EntityMapper<Long, Movie>(
         model = Model.loadSchema(Movie::class),
         meta = Meta(LongId { m -> m.id }, Table("movie")),
         idClass = Long::class,
-        enClass = Movie::class)
+        enClass = Movie::class, settings = EntitySettings(true))

--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/models/Movie.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/models/Movie.kt
@@ -2,7 +2,7 @@ package slatekit.samples.common.models
 
 import slatekit.common.DateTime
 import slatekit.common.DateTimes
-import slatekit.common.Field
+import slatekit.entities.Column
 import slatekit.entities.EntityUpdatable
 import slatekit.entities.EntityWithId
 import java.util.*
@@ -16,35 +16,35 @@ data class Movie(
         /**
          * Indexed also using uuid ( for sample purposes )
          */
-        @property:Field(length = 50, indexed = true)
+        @property:Column(length = 50, indexed = true)
         val uuid: UUID = UUID.randomUUID(),
 
 
-        @property:Field(required = true, length = 50)
+        @property:Column(required = true, length = 50)
         val title: String = "",
 
 
-        @property:Field(length = 20)
+        @property:Column(length = 20)
         val category: String = "",
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val playing: Boolean = false,
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val delivery: Delivery = Delivery.Theater,
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val cost: Int,
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val rating: Double,
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val released: DateTime
 
 ) : EntityWithId<Long>, EntityUpdatable<Long, Movie> {

--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/models/Movie.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/models/Movie.kt
@@ -5,12 +5,14 @@ import slatekit.common.DateTimes
 import slatekit.entities.Column
 import slatekit.entities.EntityUpdatable
 import slatekit.entities.EntityWithId
+import slatekit.entities.Id
 import java.util.*
 
 data class Movie(
         /**
          * Primary key ( auto-increment )
          */
+        @property:Id()
         override val id: Long = 0L,
 
         /**

--- a/src/ext/kotlin/slatekit-connectors-entities/src/main/kotlin/slatekit/connectors/entities/AppEntContext.kt
+++ b/src/ext/kotlin/slatekit-connectors-entities/src/main/kotlin/slatekit/connectors/entities/AppEntContext.kt
@@ -83,24 +83,10 @@ data class AppEntContext(
          * converts this to an app context which is basically
          * the same context without the Entities
          */
-        fun fromContext(ctx: Context, namer: Namer? = null): AppEntContext {
-            val dbCons = Connections.from(ctx.app, ctx.conf)
-            val id = Context.identity(ctx.info, ctx.envs)
+        fun fromContext(ctx: Context, namer: Namer? = null, cons:Connections? = null): AppEntContext {
+            val dbCons = cons ?: Connections.from(ctx.app, ctx.conf)
             return AppEntContext(
-                    ctx.app, ctx.args, ctx.envs, ctx.conf, ctx.logs, ctx.info, id, Entities({ con -> Db(con) }, dbCons, ctx.enc, namer = namer), dbCons, ctx.enc, ctx.dirs
-            )
-
-        }
-
-        /**
-         * converts this to an app context which is basically
-         * the same context without the Entities
-         */
-        fun fromAppContext(ctx: Context, namer: Namer? = null): AppEntContext {
-            val dbCons = Connections.from(ctx.app, ctx.conf)
-            val id = Context.identity(ctx.info, ctx.envs)
-            return AppEntContext(
-                    ctx.app, ctx.args, ctx.envs, ctx.conf, ctx.logs, ctx.info, id, Entities({ con -> Db(con) }, dbCons, ctx.enc, namer = namer), dbCons, ctx.enc, ctx.dirs
+                    ctx.app, ctx.args, ctx.envs, ctx.conf, ctx.logs, ctx.info, ctx.id, Entities({ con -> Db(con) }, dbCons, ctx.enc, namer = namer), dbCons, ctx.enc, ctx.dirs
             )
 
         }

--- a/src/ext/kotlin/slatekit-providers-logback/build.gradle
+++ b/src/ext/kotlin/slatekit-providers-logback/build.gradle
@@ -81,9 +81,9 @@ repositories {
 dependencies {
 
     //compile group: 'org.slf4j'     , name: 'slf4j-api', version: '1.7.7'
-    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.1.2'
-    compile group: 'ch.qos.logback', name: 'logback-core'   , version: '1.1.2'
-    compile group: 'org.logback-extensions', name: 'logback-ext-loggly'   , version: '0.1.2'
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    compile group: 'ch.qos.logback', name: 'logback-core'   , version: '1.2.3'
+    compile group: 'org.logback-extensions', name: 'logback-ext-loggly'   , version: '0.1.5'
 
 
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"

--- a/src/ext/kotlin/slatekit-providers-logback/src/main/kotlin/slatekit/providers/logback/LogbackLogger.kt
+++ b/src/ext/kotlin/slatekit-providers-logback/src/main/kotlin/slatekit/providers/logback/LogbackLogger.kt
@@ -14,7 +14,7 @@ class LogbackLogger(private val instance: org.slf4j.Logger) : Logger(parseLevel(
      * @param entry: 
      */
     override fun log(entry: LogEntry) {
-        when (level) {
+        when (entry.level) {
             LogLevel.Debug -> instance.debug(entry.msg, entry.ex)
             LogLevel.Info  -> instance.info (entry.msg, entry.ex)
             LogLevel.Warn  -> instance.warn (entry.msg, entry.ex)

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/log/LogEntry.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/log/LogEntry.kt
@@ -17,7 +17,7 @@ import slatekit.common.DateTime
 
 data class LogEntry(
     val name: String = "",
-    val level: LogLevel = LogLevel.Info,
+    val level: LogLevel,
     val msg: String = "",
     val ex: Exception? = null,
     val tag: String? = null,

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/log/LogLevel.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/log/LogLevel.kt
@@ -18,7 +18,7 @@ sealed class LogLevel(val name: String, val code: Int) {
     operator fun compareTo(lv: LogLevel): Int = this.code.compareTo(lv.code)
 
     object Debug : LogLevel("Debug", 1)
-    object Info  : LogLevel("Meta", 2 )
+    object Info  : LogLevel("Info", 2 )
     object Warn  : LogLevel("Warn", 3 )
     object Error : LogLevel("Error", 4)
     object Fatal : LogLevel("Fatal", 5)

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/log/LogSupport.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/log/LogSupport.kt
@@ -28,6 +28,8 @@ interface LogSupport {
 
     /** =====================================================================
      * Logging using string with optional args for formatting
+     *
+     * log.error("updating user {0}", user.id )
      * ======================================================================
      */
     @Ignore fun debug(msg: String?, vararg args:Any?) = log(LogLevel.Debug, null, msg, *args)
@@ -38,6 +40,8 @@ interface LogSupport {
 
     /** =====================================================================
      * Logging using exceptions + messages
+     *
+     * log.error( ex, "upating user {0}", user.id )
      * ======================================================================
      */
     @Ignore fun debug(ex:Exception?, msg: String?, vararg args:Any?) = log(LogLevel.Debug, ex, msg, *args)
@@ -48,6 +52,8 @@ interface LogSupport {
 
     /** =====================================================================
      * Logging using exceptions only
+     *
+     * log.error( ex )
      * ======================================================================
      */
     @Ignore fun debug(ex:Exception?) = log(LogLevel.Debug, ex, null)
@@ -58,6 +64,8 @@ interface LogSupport {
 
     /** =====================================================================
      * Lazy logging
+     *
+     * log.error( "updating user" ) { " some expensive message to build" }
      * ======================================================================
      */
     @Ignore fun debug(msg: String? = null, callback: () -> String) = log(LogLevel.Debug, msg, callback)
@@ -65,6 +73,18 @@ interface LogSupport {
     @Ignore fun warn (msg: String? = null, callback: () -> String) = log(LogLevel.Warn , msg, callback)
     @Ignore fun error(msg: String? = null, callback: () -> String) = log(LogLevel.Error, msg, callback)
     @Ignore fun fatal(msg: String? = null, callback: () -> String) = log(LogLevel.Fatal, msg, callback)
+
+    /** =====================================================================
+     * Structured logging ( key-value pairs )
+     *
+     * log.error( "updating user", listOf( "user_id" to "abc123", "promo-code" to "xyz-111" ) )
+     * ======================================================================
+     */
+    @Ignore fun debug(msg: String, pairs:List<Pair<String, Any?>>) = log(LogLevel.Debug, "$msg : ${format(pairs)}")
+    @Ignore fun info (msg: String, pairs:List<Pair<String, Any?>>) = log(LogLevel.Info , "$msg : ${format(pairs)}")
+    @Ignore fun warn (msg: String, pairs:List<Pair<String, Any?>>) = log(LogLevel.Warn , "$msg : ${format(pairs)}")
+    @Ignore fun error(msg: String, pairs:List<Pair<String, Any?>>) = log(LogLevel.Error, "$msg : ${format(pairs)}")
+    @Ignore fun fatal(msg: String, pairs:List<Pair<String, Any?>>) = log(LogLevel.Fatal, "$msg : ${format(pairs)}")
 
     /**
      * Logs an entry
@@ -122,5 +142,16 @@ interface LogSupport {
         return trace
     }
 
+
     fun format(msg:String, args:Array<out Any?>):String = msg.format(*args)
+
+    /**
+     * Format key/value pairs into "structured value"
+     * e.g. a=1, b=2, c=3 etc for easier searches in logs
+     * NOTE: Logs can be configured to output JSON and/or provide structured arguments.
+     * This varies from logging provider so this is an easier text/classic only way to do ( for now )
+     */
+    fun format(pairs:List<Pair<String, Any?>>):String  {
+        return LogUtils.format(pairs)
+    }
 }

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/log/LogUtils.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/log/LogUtils.kt
@@ -1,0 +1,39 @@
+package slatekit.common.log
+
+object LogUtils {
+    val sensitiveFields = listOf("username", "email", "phone", "password", "pswd", "firstname", "lastname")
+
+    fun keys(name:String, fields:List<Pair<String, Any?>>) {
+        val values = fields.joinToString(",") { item -> "${toKey(item.first)}=${item.second}" }
+        println("$name : $values")
+    }
+
+    /**
+     * Format key/value pairs into "structured value"
+     * e.g. a=1, b=2, c=3 etc for easier searches in logs
+     * NOTE: Logs can be configured to output JSON and/or provide structured arguments.
+     * This varies from logging provider so this is an easier text/classic only way to do ( for now )
+     */
+    fun format(pairs:List<Pair<String, Any?>>):String  {
+        // OPTIMIZATION:
+        // avoiding map/filter here to avoid unnecessary copies / loops
+        return pairs.foldIndexed("") { ndx, acc, info ->
+            val key = toKey(info.first)
+
+            // Check sensitive fields like password, email, phone,
+            when(!isSensitive(key)){
+                true -> {
+                    val prefix = if(acc.isBlank()) "" else ", "
+                    acc + "$prefix${key}=${info.second}"
+                }
+                false -> acc
+            }
+        }
+    }
+
+    @Suppress("NOTHING_TO_INLINE")
+    inline fun toKey(key:String):String = key.trim().toLowerCase().replace(" ", "-")
+
+    @Suppress("NOTHING_TO_INLINE")
+    inline fun isSensitive(key:String) : Boolean = sensitiveFields.any { key.contains(it) }
+}

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/log/Prints.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/log/Prints.kt
@@ -1,8 +1,0 @@
-package slatekit.common.log
-
-object Prints {
-    fun keys(name:String, fields:List<Pair<String, Any?>>) {
-        val values = fields.joinToString(",") { item -> "${item.first}=${item.second}" }
-        println("$name : $values")
-    }
-}

--- a/src/lib/kotlin/slatekit-db/src/main/kotlin/slatekit/db/builders/DbBuilder.kt
+++ b/src/lib/kotlin/slatekit-db/src/main/kotlin/slatekit/db/builders/DbBuilder.kt
@@ -13,6 +13,7 @@ mantra: Simplicity above all else
 package slatekit.db.builders
 
 import slatekit.common.data.DataType
+import slatekit.common.data.Encoding
 
 /**
  * Created by kishorereddy on 6/14/17.

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/Entities.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/Entities.kt
@@ -140,6 +140,10 @@ open class Entities(
      */
     fun getDb(): IDb = builder.db()
 
+    fun getDDL(entityType: KClass<*>):DDL {
+
+    }
+
     /**
      * Gets a database by its name/alias
      */
@@ -191,6 +195,18 @@ open class Entities(
      */
     inline fun <reified T> getModel(): Model {
         return getInfoByName(T::class.qualifiedName!!).model
+    }
+
+    /**
+     * Gets the model tied to the entity type T
+     */
+    inline fun getModel(cls:KClass<*>): Model {
+        return getModel(cls.qualifiedName!!)
+    }
+
+
+    inline fun getModel(qualifiedName:String): Model {
+        return getInfoByName(qualifiedName).model
     }
 
     fun getInfoByName(entityType: String): EntityContext {

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/Entities.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/Entities.kt
@@ -78,7 +78,7 @@ open class Entities(
      * which contains all the relevant info about an Entity, its id,
      * and its corresponding mapper, repo, service, etc.
      */
-    inline fun <reified TId, reified T> register(idOps:Id<TId, T>,
+    inline fun <reified TId, reified T> register(idOps:slatekit.data.core.Id<TId, T>,
                                                  table: String? = null,
                                                  vendor: Vendor = Vendor.MySql,
                                                  builder: (EntityRepo<TId, T>) -> EntityService<TId, T>) where TId : Comparable<TId>, T : Entity<TId> {
@@ -100,7 +100,7 @@ open class Entities(
         val tableInfo = Table(tableName, tableChar, tableKey)
 
         // 3. Schema / Meta data
-        val entityModel = Model.loadSchema(enType, idName, null, tableName)
+        val entityModel = Schema.load(enType, idName, null, tableName)
         val entityMeta = Meta<TId, T>(idOps, tableInfo)
 
         // 4. Mapper
@@ -139,10 +139,6 @@ open class Entities(
      * Gets the default database
      */
     fun getDb(): IDb = builder.db()
-
-    fun getDDL(entityType: KClass<*>):DDL {
-
-    }
 
     /**
      * Gets a database by its name/alias

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/Id.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/Id.kt
@@ -1,33 +1,20 @@
-/**
- * <slate_header>
- * url: www.slatekit.com
- * git: www.github.com/code-helix/slatekit
- * org: www.codehelix.co
- * author: Kishore Reddy
- * copyright: 2016 CodeHelix Solutions Inc.
- * license: refer to website and/or github
- * about: A tool-kit, utility library and server-backend
- * mantra: Simplicity above all else
- * </slate_header>
- */
-
-package slatekit.common
-
+package slatekit.entities
 
 /**
  * Used to annotate a field as an Id ( primary key with optional name
  * and whether or not it should be auto-generated
  */
 annotation class Id(
-        val generated:Boolean = true,
-        val name:String = ""
+    val generated:Boolean = true,
+    val name:String = ""
 )
+
 
 
 /**
  * Used to annotate a field as Persisted/Model field.
  */
-annotation class Field(
+annotation class Column(
     val name: String = "",
     val desc: String = "",
     val required: Boolean = true,

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/Schema.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/Schema.kt
@@ -1,0 +1,83 @@
+package slatekit.entities
+
+import slatekit.common.naming.Namer
+import slatekit.meta.Reflector
+import slatekit.meta.models.FieldCategory
+import slatekit.meta.models.Model
+import slatekit.meta.models.ModelField
+import slatekit.meta.models.ModelUtils
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty
+import kotlin.reflect.jvm.jvmErasure
+
+object Schema {
+
+    /**
+     * Builds a schema ( Model ) from the Class/Type supplied.
+     * NOTE: The mapper then works off the Model class for to/from mapping of data to model.
+     * @param dataType
+     * @return
+     */
+    @JvmStatic
+    fun load (dataType: KClass<*>, idFieldName: String? = null, namer: Namer? = null, table: String? = null): Model {
+        val modelName = dataType.simpleName ?: ""
+        val modelNameFull = dataType.qualifiedName ?: ""
+
+        // Get Id
+        val idFields = Reflector.getAnnotatedProps<Id>(dataType, Id::class)
+        val idField = idFields.firstOrNull()
+
+        // Now add all the fields.
+        val matchedFields = Reflector.getAnnotatedProps<Column>(dataType, Column::class)
+
+        // Loop through each field
+        val withAnnos = matchedFields.filter { it.second != null }
+        val fields = withAnnos.map { matchedField ->
+            val modelField = column(matchedField.first, matchedField.second!!,
+                namer, idField == null, idFieldName)
+            val finalModelField = if (!modelField.isBasicType()) {
+                val model = load(modelField.dataCls, namer = namer)
+                modelField.copy(model = model)
+            } else modelField
+            finalModelField
+        }
+        val allFields = when(idField) {
+            null -> fields
+            else -> mutableListOf(ModelField.ofId(idField.first, "", namer)).plus(fields)
+        }
+        return Model(modelName, modelNameFull, dataType, modelFields = allFields, namer = namer, tableName = table ?: modelName)
+    }
+
+
+    @JvmStatic
+    fun column(prop: KProperty<*>, anno: Column, namer:Namer?, checkForId:Boolean, idFieldName:String?):ModelField {
+        val name = if (anno.name.isNullOrEmpty()) prop.name else anno.name
+        val cat = idFieldName?.let {
+            if(it == name)
+                FieldCategory.Id
+            else
+                FieldCategory.Data
+        } ?: FieldCategory.Data
+
+        val required = anno.required
+        val length = anno.length
+        val encrypt = anno.encrypt
+        val fieldKType = prop.returnType
+        val fieldType = ModelUtils.fieldType(prop)
+        val fieldCls = fieldKType.jvmErasure
+        val field = ModelField.build(
+            prop = prop, name = name,
+            dataType = fieldCls,
+            dataFieldType = fieldType,
+            isRequired = required,
+            isIndexed = anno.indexed,
+            isUnique = anno.unique,
+            isUpdatable = anno.updatable,
+            maxLength = length,
+            encrypt = encrypt,
+            cat = cat,
+            namer = namer
+        )
+        return field
+    }
+}

--- a/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/core/EntityBuilder.kt
+++ b/src/lib/kotlin/slatekit-entities/src/main/kotlin/slatekit/entities/core/EntityBuilder.kt
@@ -87,7 +87,7 @@ open class EntityBuilder(
      * This may be removed later
      */
     fun model(entityType: KClass<*>, namer: Namer?, table: String?): Model {
-        return Model.loadSchema(entityType, EntityWithId<*>::id.name, namer, table)
+        return Schema.load(entityType, EntityWithId<*>::id.name, namer, table)
     }
 
     /**

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/EntitiesApi.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/EntitiesApi.kt
@@ -71,8 +71,7 @@ class EntitiesApi(context: AppEntContext) : ApiBase(context) {
 
     @Action(desc = "installs all the models in the default database")
     fun counts(): List<Pair<String, Long>> {
-        //return service().counts()
-        return listOf()
+        return service().counts()
     }
 
     @Action(desc = "generates sql install files for the model")

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/EntitiesApi.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/EntitiesApi.kt
@@ -65,7 +65,8 @@ class EntitiesApi(context: AppEntContext) : ApiBase(context) {
 
     @Action(desc = "installs all the models in the default database")
     fun names(): List<Pair<String, String>> {
-        return service().names()
+        val service = service()
+        return service.names()
     }
 
     @Action(desc = "installs all the models in the default database")
@@ -104,9 +105,7 @@ class EntitiesApi(context: AppEntContext) : ApiBase(context) {
         return service().connectionByName(name)
     }
 
-    private val dbLookup by lazy { Connections.from(context.app, context.conf) }
-
     private fun service(): MigrationService {
-        return MigrationService(appContext.ent, dbLookup, MigrationSettings(), context.dirs)
+        return MigrationService(appContext.ent, appContext.dbs, MigrationSettings(), context.dirs)
     }
 }

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/ModuleApi.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/apis/ModuleApi.kt
@@ -29,6 +29,16 @@ import slatekit.results.Notice
 import slatekit.results.Success
 import slatekit.results.Try
 
+/**
+ * The modules service supports the install of a "feature" module.
+ * A feature module is a logical feature/product area of an application. It can:
+ * 1. Optionally contain 1 or more @see[slatekit.entities.Entity] that is mapped to a database table
+ * 2. Can be installed as a table to the database
+ * 3. Can be uninstalled as a table in the database
+ * 4. Registered so that we know what modules are set up
+ *
+ * This service provides the functionality for installing, uninstalling, feature modules.
+ */
 @Api(area = "setup", name = "modules", desc = "management of system modules",
         auth = AuthModes.KEYED, roles = ["admin"], verb = Verbs.AUTO, sources = [Sources.ALL])
 class ModuleApi(val ctx: slatekit.integration.mods.ModuleContext, override val context: Context) : slatekit.apis.support.FileSupport {
@@ -38,21 +48,44 @@ class ModuleApi(val ctx: slatekit.integration.mods.ModuleContext, override val c
 
     private var _items = ListMap<String, Module>()
 
+    /**
+     * Creates the `mod` table in the database for storing all installed modules
+     */
     @Action(desc = "sets up the db to support modules")
     suspend fun setupDb(): Try<Any> {
         return ctx.setup.install(slatekit.integration.mods.Mod::class.qualifiedName!!, "1", "", "")
     }
 
+    /**
+     * Gets the names of all modules in the database
+     */
+    @Action(desc = "gets the names of the modules")
+    fun names(): List<String> {
+        return _items.all().map { "${it.info.name} ver: ${it.info.version}" }
+    }
+
+    /**
+     * Gets a list of all installed modules ( from the `module` table in the database )
+     */
     @Action(desc = "gets all installed modules")
     suspend fun installed(): List<slatekit.integration.mods.Mod> {
         return ctx.service.getAll()
     }
 
-    @Action(desc = "creates a new invitee")
+    /**
+     * Get a list of all installed modules in the database
+     */
+    @Action(desc = "gets all enabled modules")
     suspend fun enabled(): List<slatekit.integration.mods.Mod> {
-        return ctx.service.find { where("isEnabled", Op.Eq, true) }
+        return ctx.service.find { where(Mod::isEnabled.name, Op.Eq, true) }
     }
 
+    /**
+     * Installs all modules.
+     * Notes:
+     * 1. This installs tables associated with any entities linked to the module
+     * 2. Calls the install method on the module
+     */
     @Action(desc = "installs all modules from initial setup")
     suspend fun installAll(): Notice<Any> {
         val res = _items.all().map { module -> installUpdate(module, false) }
@@ -60,11 +93,18 @@ class ModuleApi(val ctx: slatekit.integration.mods.ModuleContext, override val c
         return finalResult
     }
 
+    /**
+     * Installs only a single module based on its name supplied
+     * @param name: The fully qualified name of the module ( @see[slatekit.integration.mods.ModuleInfo.name]
+     */
     @Action(desc = "installs a specific module")
     suspend fun installByName(name: String): Notice<Any> {
         return _items[name]?.let { installUpdate(it, false) } ?: Failure("Unknown module : $name")
     }
 
+    /**
+     * Generates a sql script containing the DDL sql statements for all entities
+     */
     @Action(desc = "generates sql scripts for all models")
     fun script(): List<String> {
         val scripts = _items.all().map { module ->
@@ -74,16 +114,18 @@ class ModuleApi(val ctx: slatekit.integration.mods.ModuleContext, override val c
         return scripts.flatten()
     }
 
+    /**
+     * Force installs a specific module
+     */
     @Action(desc = "forces the install of a specific module or updates it. updates the mod entry and creates table")
     suspend fun forceInstallByName(name: String): Notice<Any> {
         return _items[name]?.let { installUpdate(it, true) } ?: Failure("Unknown module : $name")
     }
 
-    @Action(desc = "gets the names of the modules")
-    fun names(): List<String> {
-        return _items.all().map { "${it.info.name} ver: ${it.info.version}" }
-    }
-
+    /**
+     * Uninstalls all modules ( this is destructive ) and will delete all data/tables.
+     * Should only be used for administrative purposes and initial setup
+     */
     @Action(desc = "gets the names of the modules")
     suspend fun uninstallAll(): Try<String> {
         val all = _items.all().map { it.info.name }
@@ -116,16 +158,19 @@ class ModuleApi(val ctx: slatekit.integration.mods.ModuleContext, override val c
         mod.register()
     }
 
+    /**
+     * Seeds all modules by calling its seed method.
+     */
     @Action(desc = "seeds all the modules")
     fun seed(): Notice<Any> {
-        val res = _items.all().map { module -> seedMod(module) }
-        val finalResult = res.reduce({ acc, item -> if (!acc.success) acc else item })
+        val res = _items.all().map { module -> seed(module) }
+        val finalResult = res.reduce { acc, item -> if (!acc.success) acc else item }
         return finalResult
     }
 
     @Action(desc = "seeds all the modules")
     fun seedModule(name: String): Notice<Any> {
-        return _items[name]?.let { seedMod(it) } ?: Failure("Unknown module : $name")
+        return _items[name]?.let { seed(it) } ?: Failure("Unknown module : $name")
     }
 
     /**
@@ -134,7 +179,7 @@ class ModuleApi(val ctx: slatekit.integration.mods.ModuleContext, override val c
      * @param mod
      * @return
      */
-    private fun seedMod(mod: Module): Notice<Any> {
+    private fun seed(mod: Module): Notice<Any> {
         val result = try {
             mod.seed()
             Success("Seeded module: " + mod.info.name)

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/mods/Mod.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/mods/Mod.kt
@@ -14,54 +14,54 @@
 package slatekit.integration.mods
 
 import slatekit.common.DateTime
-import slatekit.common.Field
+import slatekit.entities.Column
 import slatekit.entities.EntityWithUUID
 import slatekit.entities.EntityWithId
 
 data class Mod(
-    @property:Field()
+    @property:Column()
     override val id: Long = 0L,
 
-    @property:Field(length = 50)
+    @property:Column(length = 50)
     val name: String = "",
 
-    @property:Field(length = 200)
+    @property:Column(length = 200)
     val desc: String = "",
 
-    @property:Field(length = 30)
+    @property:Column(length = 30)
     val version: String = "",
 
-    @property:Field()
+    @property:Column()
     val isInstalled: Boolean = false,
 
-    @property:Field()
+    @property:Column()
     val isEnabled: Boolean = false,
 
-    @property:Field()
+    @property:Column()
     val isDbDependent: Boolean = false,
 
-    @property:Field()
+    @property:Column()
     val totalModels: Int = 0,
 
-    @property:Field(length = 50)
+    @property:Column(length = 50)
     val source: String = "",
 
-    @property:Field(length = 100)
+    @property:Column(length = 100)
     val dependencies: String = "",
 
-    @property:Field()
+    @property:Column()
     val createdAt: DateTime = DateTime.now(),
 
-    @property:Field()
+    @property:Column()
     val createdBy: Int = 0,
 
-    @property:Field()
+    @property:Column()
     val updatedAt: DateTime = DateTime.now(),
 
-    @property:Field()
+    @property:Column()
     val updatedBy: Int = 0,
 
-    @property:Field(length = 50)
+    @property:Column(length = 50)
     override val uuid: String = ""
 )
     : EntityWithId<Long>, EntityWithUUID {

--- a/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/mods/Mod.kt
+++ b/src/lib/kotlin/slatekit-integration/src/main/kotlin/slatekit/integration/mods/Mod.kt
@@ -14,12 +14,13 @@
 package slatekit.integration.mods
 
 import slatekit.common.DateTime
-import slatekit.entities.Column
 import slatekit.entities.EntityWithUUID
 import slatekit.entities.EntityWithId
+import slatekit.entities.Id
+import slatekit.entities.Column
 
 data class Mod(
-    @property:Column()
+    @property:Id()
     override val id: Long = 0L,
 
     @property:Column(length = 50)

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/Field.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/Field.kt
@@ -1,0 +1,32 @@
+/**
+ * <slate_header>
+ * url: www.slatekit.com
+ * git: www.github.com/code-helix/slatekit
+ * org: www.codehelix.co
+ * author: Kishore Reddy
+ * copyright: 2016 CodeHelix Solutions Inc.
+ * license: refer to website and/or github
+ * about: A tool-kit, utility library and server-backend
+ * mantra: Simplicity above all else
+ * </slate_header>
+ */
+
+package slatekit.meta.models
+
+
+
+/**
+ * Used to annotate a field as Persisted/Model field.
+ */
+annotation class Field(
+    val name: String = "",
+    val desc: String = "",
+    val required: Boolean = true,
+    val unique: Boolean = false,
+    val updatable: Boolean = true,
+    val indexed: Boolean = false,
+    val length: Int = 0,
+    val defaultVal: String = "",
+    val encrypt: Boolean = false,
+    val example: String = ""
+)

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/Id.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/Id.kt
@@ -1,0 +1,10 @@
+package slatekit.meta.models
+
+/**
+ * Used to annotate a field as an Id ( primary key with optional name
+ * and whether or not it should be auto-generated
+ */
+annotation class Id(
+        val generated:Boolean = true,
+        val name:String = ""
+)

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/Model.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/Model.kt
@@ -13,8 +13,6 @@
 
 package slatekit.meta.models
 
-import slatekit.common.Field
-import slatekit.common.Id
 import slatekit.common.naming.Namer
 import slatekit.common.ext.orElse
 import slatekit.meta.Reflector
@@ -104,7 +102,7 @@ class Model(
          * @return
          */
         @JvmStatic
-        fun loadSchema(dataType: KClass<*>, idFieldName: String? = null, namer: Namer? = null, table: String? = null): Model {
+        fun load (dataType: KClass<*>, idFieldName: String? = null, namer: Namer? = null, table: String? = null): Model {
             val modelName = dataType.simpleName ?: ""
             val modelNameFull = dataType.qualifiedName ?: ""
 
@@ -121,7 +119,7 @@ class Model(
                 val modelField = ModelField.ofData(matchedField.first, matchedField.second!!,
                         namer, idField == null, idFieldName)
                 val finalModelField = if (!modelField.isBasicType()) {
-                    val model = loadSchema(modelField.dataCls, namer = namer)
+                    val model = load(modelField.dataCls, namer = namer)
                     modelField.copy(model = model)
                 } else modelField
                 finalModelField

--- a/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelField.kt
+++ b/src/lib/kotlin/slatekit-meta/src/main/kotlin/slatekit/meta/models/ModelField.kt
@@ -13,7 +13,6 @@
 
 package slatekit.meta.models
 
-import slatekit.common.Field
 import slatekit.common.data.DataType
 import slatekit.common.naming.Namer
 import slatekit.meta.KTypes

--- a/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/MigrationService.kt
+++ b/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/MigrationService.kt
@@ -40,7 +40,6 @@ class MigrationService(
 
     fun names(): List<Pair<String, String>> = entities.getEntities().map {
         Pair(it.entityTypeName, it.model.table )
-        return listOf()
     }
 
 

--- a/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/MigrationService.kt
+++ b/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/MigrationService.kt
@@ -128,7 +128,6 @@ class MigrationService(
             filePath
         } ?: "Folders not available, sql files not written"
         return slatekit.results.Success(filePath)
-        return Tries.success("")
     }
 
     fun generateSqlAllUninstall(): Try<String> {
@@ -149,7 +148,6 @@ class MigrationService(
             filePath
         } ?: "Folders not available, sql files not written"
         return slatekit.results.Success(filePath)
-        return Tries.success("")
     }
 
     fun deleteAll(): Try<List<String>> {
@@ -194,7 +192,6 @@ class MigrationService(
         val path = result.second
         val info = if (success) "generated sql for model: $moduleName $path" else "error generating sql"
         return if (success) slatekit.results.Success(sql, msg = info) else slatekit.results.Failure(Exception(info), msg = info)
-        return Tries.success(listOf())
     }
 
     fun connection(): Notice<DbCon> {
@@ -222,7 +219,6 @@ class MigrationService(
         } catch (ex: Exception) {
             slatekit.results.Failure(ex, msg = "Unable to delete :$table. ${ex.message}")
         }
-        return Tries.success("")
     }
 
     private fun each(operation: (EntityContext) -> Try<String>): Try<List<String>> {

--- a/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/MigrationService.kt
+++ b/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/MigrationService.kt
@@ -26,6 +26,7 @@ import slatekit.results.Notice
 import slatekit.results.Success
 import slatekit.results.Try
 import slatekit.results.builders.Tries
+import slatekit.results.getOrElse
 
 /**
  * Created by kreddy on 3/23/2016.
@@ -38,7 +39,7 @@ class MigrationService(
 ) {
 
     fun names(): List<Pair<String, String>> = entities.getEntities().map {
-        //Pair(it.entityTypeName, it.entityRepoInstance.name() )
+        Pair(it.entityTypeName, it.entityRepoInstance.name() )
         return listOf()
     }
 
@@ -110,47 +111,47 @@ class MigrationService(
     }
 
     fun generateSqlAllInstall(): Try<String> {
-//        val fileName = "sql-all-install-" + DateTime.now().toStringNumeric()
-//        val results = entities.getEntities().map { entity ->
-//            val result = generateSql(entity.entityTypeName)
-//            result.map {
-//                val allSqlForModel = it.joinToString(newline)
-//                allSqlForModel
-//            }
-//        }
-//        val succeeded = results.filter { it.success }
-//        val allSql = succeeded.fold("") { acc, result ->
-//            acc + newline + "-- ${result.desc}" + newline + result.getOrElse { "Error generating sql" }
-//        }
-//        val finalFileName = "$fileName.sql"
-//        val filePath = folders?.let {
-//            Files.writeDatedFile(folders.pathToOutputs, finalFileName, allSql)
-//            val filePath = folders.pathToOutputs + Props.pathSeparator + finalFileName
-//            filePath
-//        } ?: "Folders not available, sql files not written"
-//        return slatekit.results.Success(filePath)
+        val fileName = "sql-all-install-" + DateTime.now().toStringNumeric()
+        val results = entities.getEntities().map { entity ->
+            val result = generateSql(entity.entityTypeName)
+            result.map {
+                val allSqlForModel = it.joinToString(newline)
+                allSqlForModel
+            }
+        }
+        val succeeded = results.filter { it.success }
+        val allSql = succeeded.fold("") { acc, result ->
+            acc + newline + "-- ${result.desc}" + newline + result.getOrElse { "Error generating sql" }
+        }
+        val finalFileName = "$fileName.sql"
+        val filePath = folders?.let {
+            Files.writeDatedFile(folders.pathToOutputs, finalFileName, allSql)
+            val filePath = folders.pathToOutputs + Props.pathSeparator + finalFileName
+            filePath
+        } ?: "Folders not available, sql files not written"
+        return slatekit.results.Success(filePath)
         return Tries.success("")
     }
 
     fun generateSqlAllUninstall(): Try<String> {
-//        val fileName = "sql-all-uninstall-" + DateTime.now().toStringNumeric()
-//        val results = entities.getEntities().map { entity ->
-//            val ormEntityInfo = entity
-//            val dropTable = entities.getDbSource().dropTable(ormEntityInfo.model.table)
-//
-//            Success(dropTable, msg = "Dropping table for model : " + entity.model.name)
-//        }
-//        val succeeded = results.filter { it.success }
-//        val allSql = succeeded.fold("") { acc, result ->
-//            acc + newline + "-- ${result.desc}" + newline + result.getOrElse { "Error generating sql" }
-//        }
-//        val finalFileName = "$fileName.sql"
-//        val filePath = folders?.let {
-//            Files.writeDatedFile(folders.pathToOutputs, finalFileName, allSql)
-//            val filePath = folders.pathToOutputs + Props.pathSeparator + finalFileName
-//            filePath
-//        } ?: "Folders not available, sql files not written"
-//        return slatekit.results.Success(filePath)
+        val fileName = "sql-all-uninstall-" + DateTime.now().toStringNumeric()
+        val results = entities.getEntities().map { entity ->
+            val ormEntityInfo = entity
+            val dropTable = entities.getDbSource().dropTable(ormEntityInfo.model.table)
+
+            Success(dropTable, msg = "Dropping table for model : " + entity.model.name)
+        }
+        val succeeded = results.filter { it.success }
+        val allSql = succeeded.fold("") { acc, result ->
+            acc + newline + "-- ${result.desc}" + newline + result.getOrElse { "Error generating sql" }
+        }
+        val finalFileName = "$fileName.sql"
+        val filePath = folders?.let {
+            Files.writeDatedFile(folders.pathToOutputs, finalFileName, allSql)
+            val filePath = folders.pathToOutputs + Props.pathSeparator + finalFileName
+            filePath
+        } ?: "Folders not available, sql files not written"
+        return slatekit.results.Success(filePath)
         return Tries.success("")
     }
 
@@ -170,32 +171,32 @@ class MigrationService(
      * @return
      */
     fun generateSql(moduleName: String, version: String = ""): Try<List<String>> {
-//        val result = try {
-//            val fullName = moduleName
-//            val info = entities.getInfoByName(moduleName)
-//            val ddl = entities.sqlBuilder(fullName)
-//            val sqlTable = ddl.createTable(info.model)
-//            val sqlIndexes = ddl.createIndex(info.model)
-//            val sql: List<String> = listOf(sqlTable).plus(sqlIndexes)
-//            val filePath = if (settings.enableOutput) {
-//                folders?.let { folders ->
-//                    val fileName = "model-${info.model.name}.sql"
-//                    Files.writeDatedFile(folders.pathToOutputs, fileName, sql.joinToString(newline))
-//                    folders.pathToOutputs + Props.pathSeparator + fileName
-//                }
-//            } else {
-//                ""
-//            }
-//            Triple(true, filePath, sql)
-//        } catch (ex: Exception) {
-//            Triple(false, ex.message, listOf(""))
-//        }
-//
-//        val success = result.first
-//        val sql = result.third
-//        val path = result.second
-//        val info = if (success) "generated sql for model: $moduleName $path" else "error generating sql"
-//        return if (success) slatekit.results.Success(sql, msg = info) else slatekit.results.Failure(Exception(info), msg = info)
+        val result = try {
+            val fullName = moduleName
+            val info = entities.getInfoByName(moduleName)
+            val ddl = entities.sqlBuilder(fullName)
+            val sqlTable = ddl.createTable(info.model)
+            val sqlIndexes = ddl.createIndex(info.model)
+            val sql: List<String> = listOf(sqlTable).plus(sqlIndexes)
+            val filePath = if (settings.enableOutput) {
+                folders?.let { folders ->
+                    val fileName = "model-${info.model.name}.sql"
+                    Files.writeDatedFile(folders.pathToOutputs, fileName, sql.joinToString(newline))
+                    folders.pathToOutputs + Props.pathSeparator + fileName
+                }
+            } else {
+                ""
+            }
+            Triple(true, filePath, sql)
+        } catch (ex: Exception) {
+            Triple(false, ex.message, listOf(""))
+        }
+
+        val success = result.first
+        val sql = result.third
+        val path = result.second
+        val info = if (success) "generated sql for model: $moduleName $path" else "error generating sql"
+        return if (success) slatekit.results.Success(sql, msg = info) else slatekit.results.Failure(Exception(info), msg = info)
         return Tries.success(listOf())
     }
 
@@ -212,18 +213,18 @@ class MigrationService(
     }
 
     private fun operate(operationName: String, entityName: String, sqlBuilder: (EntityContext, String) -> String): Try<String> {
-//        val ent = entities.getInfoByName(entityName)
-//        val svc = entities.getSvcByTypeName(entityName)
-//        val model = entities.getModel(entityName)
-//        val table = model?.table ?: throw Exception("Unknown model : $entityName")
-//        val sql = sqlBuilder(ent, table)
-//        return try {
-//            val db = entities.getDb()
-//            db.update(sql)
-//            slatekit.results.Success("Operation $operationName successful on $table")
-//        } catch (ex: Exception) {
-//            slatekit.results.Failure(ex, msg = "Unable to delete :$table. ${ex.message}")
-//        }
+        val ent = entities.getInfoByName(entityName)
+        val svc = entities.getServiceByTypeName(entityName)
+        val model = entities.getModel(entityName)
+        val table = model?.table ?: throw Exception("Unknown model : $entityName")
+        val sql = sqlBuilder(ent, table)
+        return try {
+            val db = entities.getDb()
+            db.update(sql)
+            slatekit.results.Success("Operation $operationName successful on $table")
+        } catch (ex: Exception) {
+            slatekit.results.Failure(ex, msg = "Unable to delete :$table. ${ex.message}")
+        }
         return Tries.success("")
     }
 

--- a/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/SqlBuilder.kt
+++ b/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/SqlBuilder.kt
@@ -16,6 +16,12 @@ interface SqlBuilder {
      */
     fun create(model: Model): String
 
+
+    fun remove(model: Model): String
+
+
+    fun clear(model: Model): String
+
     /**
      * Creates primary key DDL
      */

--- a/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/SqlBuilder.kt
+++ b/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/SqlBuilder.kt
@@ -1,140 +1,35 @@
 package slatekit.migrations
 
 
-import slatekit.common.naming.Namer
-import slatekit.common.data.DataType
-import slatekit.common.data.Encoding
-import slatekit.common.newline
-import slatekit.data.syntax.Types
+import slatekit.data.sql.Dialect
 import slatekit.meta.models.Model
 
 /**
- *
- * 1. CREATE INDEX idx_lastname ON message (status);
- * 2. ALTER TABLE message DROP INDEX idx_status;
- * 3. ALTER TABLE message ADD UNIQUE (uuid);
+ * DDL building is very basic, just deal w/ the table creation only.
+ * All other future migrations are based on SQL files.
  */
-open class SqlBuilder(val types: Types, val namer: Namer?) {
-    private val defaultID = "id"
+interface SqlBuilder {
+    val dialect: Dialect
 
     /**
      * Builds the table DDL sql statement using the model supplied.
      */
-    fun createTable(model:Model): String
-    {
-        val buff = StringBuilder()
+    fun create(model: Model): String
 
-        // 1. build the "CREATE <tablename>
-        buff.append(createTableName(model))
-
-        // 2. build the primary key column
-        val idCol = model.idField?.storedName ?: defaultID
-        buff.append(createKey(idCol))
-
-        // 3. Now build all the columns
-        // Get only fields ( excluding primary key )
-        // Build sql for the data fields.
-        val dataFieldSql = createColumns(null, model, true)
-        buff.append(dataFieldSql)
-
-        // 4. finish the construction and get the sql.
-        buff.append(" );")
-        val sql = buff.toString()
-        return sql
-    }
-
-
-    fun createTableName(model:Model): String {
-        val name = namer?.rename(model.table) ?: model.table
-        return "create table `$name` ( $newline"
-    }
-
-
-    fun createKey(name: String): String
-    {
-        val finalName = Encoding.ensureField(name)
-        return "`$finalName` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY"
-    }
-
-
-    fun createIndex(model: Model): List<String> {
-        val tableName = namer?.rename(model.name) ?: model.name
-        val indexes = model.fields.filter { it.isIndexed }
-        val indexSql = indexes.map { field ->
-            "CREATE INDEX idx_${field.storedName} ON $tableName (${field.storedName});"
-        }
-        // db.execute(indexSql)
-
-        val uniques = model.fields.filter { it.isUnique }
-        val uniqueSql = uniques.map { field ->
-            "ALTER TABLE $tableName ADD UNIQUE (${field.storedName});"
-        }
-        return indexSql.plus(uniqueSql)
-    }
-
+    /**
+     * Creates primary key DDL
+     */
+    fun createPrimaryKey(name: String): String
 
     /**
      * Builds the table DDL sql statement using the model supplied.
      */
     fun createColumns(prefix: String?, model: Model, filterId: Boolean): String
-    {
-        val buff = StringBuilder()
-        val idCol = model.idField?.storedName ?: defaultID
-
-        // 3. Now build all the columns
-        // Get only fields ( excluding primary key )
-        val dataFields = if (filterId) model.fields.filter { idCol.compareTo(it.name) != 0 } else model.fields
-
-        // Build sql for the data fields.
-        val dataFieldSql = dataFields.fold("") { acc, field ->
-            val finalStoredName = prefix?.let { prefix + "_" + field.storedName } ?: field.storedName
-            if (field.isEnum) {
-                acc + ", " + createCol(finalStoredName, DataType.DTInt, field.isRequired, field.maxLength)
-            } else if (field.model != null) {
-                val sql = field.model?.let { createColumns(field.storedName, it, false) }
-                acc + sql
-            } else {
-                val sqlType = DataType.fromJava(field.dataCls.java)
-                acc + ", " + createCol(finalStoredName, sqlType, field.isRequired, field.maxLength)
-            }
-        }
-        buff.append(dataFieldSql)
-
-        val sql = buff.toString()
-        return sql
-    }
-
-
-    fun createCol(name: String, dataType: DataType, required: Boolean, maxLen: Int): String {
-        val nullText = if (required) "NOT NULL" else ""
-        val colType = colType(dataType, maxLen)
-        val colName = colName(name)
-
-        val sql = " $newline$colName $colType $nullText"
-        return sql
-    }
-
 
     /**
-     * Builds a valid column name
+     * Create index on column
      */
-    fun colName(name: String): String = "`" + Encoding.ensureField(name) + "`"
-
-
-    /**
-     * Builds a valid column type
-     */
-    fun colType(colType: DataType, maxLen: Int): String {
-        return if (colType == DataType.DTText && maxLen == -1)
-            types.textType.dbType
-        else if (colType == DataType.DTString && maxLen == -1)
-            types.textType.dbType
-        else if (colType == DataType.DTString)
-            types.stringType.dbType + "($maxLen)"
-        else if (colType == DataType.DTUUID || colType == DataType.DTULID || colType == DataType.DTUPID)
-            types.stringType.dbType + "($maxLen)"
-        else
-            types.lookup[colType]?.dbType ?: ""
-
-    }
+    fun createIndexes(model: Model): List<String>
 }
+
+

--- a/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/SqlBuilderDDL.kt
+++ b/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/SqlBuilderDDL.kt
@@ -1,0 +1,125 @@
+package slatekit.migrations
+
+import slatekit.common.data.DataType
+import slatekit.common.naming.Namer
+import slatekit.common.newline
+import slatekit.data.sql.Dialect
+import slatekit.meta.models.Model
+
+/**
+ * 1. CREATE INDEX idx_lastname ON message (status);
+ * 2. ALTER TABLE message DROP INDEX idx_status;
+ * 3. ALTER TABLE message ADD UNIQUE (uuid);
+ */
+open class SqlBuilderDDL(override val dialect: Dialect, val namer: Namer?) : SqlBuilder {
+    private val defaultID = "id"
+    private val types = dialect.types
+
+    /**
+     * Builds the create table DDL for this model
+     */
+    override fun create(model: Model): String
+    {
+        val buff = StringBuilder()
+
+        // 1. build the "CREATE <tablename>
+        val tableName = dialect.encode(model.table)
+        buff.append(tableName)
+
+        // 2. build the primary key column
+        val idCol = model.idField?.storedName ?: defaultID
+        buff.append(createPrimaryKey(idCol))
+
+        // 3. Now build all the columns
+        // Get only fields ( excluding primary key )
+        // Build sql for the data fields.
+        val dataFieldSql = createColumns(null, model, true)
+        buff.append(dataFieldSql)
+
+        // 4. finish the construction and get the sql.
+        buff.append(" );")
+        val sql = buff.toString()
+        return sql
+    }
+
+
+    override fun createPrimaryKey(name: String): String
+    {
+        val finalName = dialect.encode(name)
+        return "$finalName BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY"
+    }
+
+
+    /**
+     * Builds the table DDL sql statement using the model supplied.
+     */
+    override fun createColumns(prefix: String?, model: Model, filterId: Boolean): String
+    {
+        val buff = StringBuilder()
+        val idCol = model.idField?.storedName ?: defaultID
+
+        // 3. Now build all the columns
+        // Get only fields ( excluding primary key )
+        val dataFields = if (filterId) model.fields.filter { idCol.compareTo(it.name) != 0 } else model.fields
+
+        // Build sql for the data fields.
+        val dataFieldSql = dataFields.fold("") { acc, field ->
+            val finalStoredName = prefix?.let { prefix + "_" + field.storedName } ?: field.storedName
+            if (field.isEnum) {
+                acc + ", " + createCol(finalStoredName, DataType.DTInt, field.isRequired, field.maxLength)
+            } else if (field.model != null) {
+                val sql = field.model?.let { createColumns(field.storedName, it, false) }
+                acc + sql
+            } else {
+                val sqlType = DataType.fromJava(field.dataCls.java)
+                acc + ", " + createCol(finalStoredName, sqlType, field.isRequired, field.maxLength)
+            }
+        }
+        buff.append(dataFieldSql)
+
+        val sql = buff.toString()
+        return sql
+    }
+
+
+    override fun createIndexes(model: Model): List<String> {
+        val tableName = namer?.rename(model.name) ?: model.name
+        val indexes = model.fields.filter { it.isIndexed }
+        val indexSql = indexes.map { field ->
+            "CREATE INDEX idx_${field.storedName} ON $tableName (${field.storedName});"
+        }
+        val uniques = model.fields.filter { it.isUnique }
+        val uniqueSql = uniques.map { field ->
+            "ALTER TABLE $tableName ADD UNIQUE (${field.storedName});"
+        }
+        return indexSql.plus(uniqueSql)
+    }
+
+
+    private fun createCol(name: String, dataType: DataType, required: Boolean, maxLen: Int): String {
+        val nullText = if (required) "NOT NULL" else ""
+        val colType = colType(dataType, maxLen)
+        val colName = dialect.encode(name)
+
+        val sql = " $newline$colName $colType $nullText"
+        return sql
+    }
+
+
+    /**
+     * Builds a valid column type
+     */
+    private fun colType(colType: DataType, maxLen: Int): String {
+        return if (colType == DataType.DTText && maxLen == -1)
+            types.textType.dbType
+        else if (colType == DataType.DTString && maxLen == -1)
+            types.textType.dbType
+        else if (colType == DataType.DTString)
+            types.stringType.dbType + "($maxLen)"
+        else if (colType == DataType.DTUUID || colType == DataType.DTULID || colType == DataType.DTUPID)
+            types.stringType.dbType + "($maxLen)"
+        else
+            types.lookup[colType]?.dbType ?: ""
+
+    }
+}

--- a/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/SqlBuilderDDL.kt
+++ b/src/lib/kotlin/slatekit-migrations/src/main/kotlin/slatekit/migrations/SqlBuilderDDL.kt
@@ -95,7 +95,7 @@ open class SqlBuilderDDL(override val dialect: Dialect, val namer: Namer?) : Sql
 
 
     override fun createIndexes(model: Model): List<String> {
-        val tableName = namer?.rename(model.name) ?: model.name
+        val tableName = dialect.encode(model.table)
         val indexes = model.fields.filter { it.isIndexed }
         val indexSql = indexes.map { field ->
             "CREATE INDEX idx_${field.storedName} ON $tableName (${field.storedName});"

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/LogTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/LogTests.kt
@@ -45,6 +45,16 @@ class LogTests {
     }
 
 
+    @Test fun can_build_message_with_key_value_pairs(){
+        val info = listOf("a" to 1, "b" to true, "email" to "user1@gmail.com", "c" to "kotlin", "phone" to "123-456-7890", "d" to 2.3)
+        val logger = MemoryLogger(LogLevel.Info)
+        logger.info("pairs", info)
+        val actual = logger.entries.first().msg
+        val expected = "pairs : a=1, b=true, c=kotlin, d=2.3"
+        Assert.assertEquals(expected, actual)
+    }
+
+
     @Test fun can_ensure_level() {
         fun test(level: LogLevel) {
             val logger = MemoryLogger(level)

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Data_02_Mappers_Encode.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Data_02_Mappers_Encode.kt
@@ -7,6 +7,7 @@ import slatekit.common.data.DataType
 import slatekit.data.core.LongId
 import slatekit.data.core.Meta
 import slatekit.data.core.Table
+import slatekit.entities.Schema
 import slatekit.entities.mapper.EntityEncoder
 import slatekit.entities.mapper.EntitySettings
 import slatekit.meta.models.Model
@@ -41,7 +42,7 @@ class Data_02_Mappers_Encode {
 
     @Test
     fun can_encode_model_immutable() {
-        val model = Model.loadSchema(SampleEntityImmutable::class)
+        val model = Schema.load(SampleEntityImmutable::class)
         val mapper = EntityEncoder<Long, SampleEntityImmutable>(model, EntitySetup.meta, settings = EntitySettings(false), encryptor = EntitySetup.enc)
         val sample = EntitySetup.sampleImmutable()
         val values = mapper.encode(sample, DataAction.Create, EntitySetup.enc)
@@ -55,7 +56,7 @@ class Data_02_Mappers_Encode {
 
     @Test
     fun can_encode_model_mutable() {
-        val model = Model.loadSchema(SampleEntityMutable::class)
+        val model = Schema.load(SampleEntityMutable::class)
         val meta = Meta<Long, SampleEntityMutable>(LongId { m -> m.id }, Table("sample1"))
         val mapper = EntityEncoder<Long, SampleEntityMutable>(model, meta, settings = EntitySettings(false), encryptor = EntitySetup.enc)
         val sample = EntitySetup.sampleMutable()

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Data_03_Statement_Syntax.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Data_03_Statement_Syntax.kt
@@ -8,10 +8,12 @@ import slatekit.data.sql.Insert
 import slatekit.data.sql.Update
 import slatekit.data.sql.vendors.MySqlDialect
 import slatekit.data.sql.vendors.MySqlProvider
+import slatekit.entities.Schema
 import slatekit.entities.mapper.EntityMapper
 import slatekit.entities.mapper.EntitySettings
 import slatekit.meta.models.Model
 import slatekit.migrations.SqlBuilder
+import slatekit.migrations.SqlBuilderDDL
 import test.setup.Group
 import test.setup.Member
 import test.setup.User5
@@ -20,7 +22,7 @@ class Data_03_Statement_Syntax {
 
     @Test
     fun can_build_insert() {
-        val model = Model.loadSchema(SampleEntityImmutable::class)
+        val model = Schema.load(SampleEntityImmutable::class)
         val mapper = EntityMapper<Long, SampleEntityImmutable>(model, EntitySetup.meta, Long::class, SampleEntityImmutable::class, EntitySettings(false))
         val stmt = Insert<Long, SampleEntityImmutable>(MySqlDialect, EntitySetup.meta, mapper)
         val sample = EntitySetup.sampleImmutable()
@@ -32,7 +34,7 @@ class Data_03_Statement_Syntax {
 
     @Test
     fun can_build_update() {
-        val model = Model.loadSchema(SampleEntityImmutable::class)
+        val model = Schema.load(SampleEntityImmutable::class)
         val mapper = EntityMapper<Long, SampleEntityImmutable>(model, EntitySetup.meta, Long::class, SampleEntityImmutable::class, EntitySettings(false))
         val stmt = Update<Long, SampleEntityImmutable>(MySqlDialect, EntitySetup.meta, mapper)
         val sample = EntitySetup.sampleImmutable()
@@ -44,9 +46,9 @@ class Data_03_Statement_Syntax {
 
     @Test
     fun can_build_ddl_1() {
-        val model = Model.loadSchema(SampleEntityImmutable::class, table = "sample1")
-        val builder = SqlBuilder(Types(), null)
-        val actual = builder.createTable(model)
+        val model = Schema.load(SampleEntityImmutable::class, table = "sample1")
+        val builder = SqlBuilderDDL(MySqlDialect, null)
+        val actual = builder.create(model)
         val expected = """create table `sample1` ( 
 `id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,  
 `test_string` NVARCHAR(30) NOT NULL,  
@@ -63,26 +65,13 @@ class Data_03_Statement_Syntax {
 `test_localdatetime` DATETIME NOT NULL,  
 `test_zoneddatetime` DATETIME NOT NULL,  
 `test_uuid` NVARCHAR(50) NOT NULL,  
-`test_uniqueid` NVARCHAR(50) NOT NULL,  
+`test_uniqueId` NVARCHAR(50) NOT NULL,  
 `test_object_addr` NVARCHAR(40) NOT NULL,  
 `test_object_city` NVARCHAR(30) NOT NULL,  
 `test_object_state` NVARCHAR(20) NOT NULL,  
 `test_object_country` INTEGER NOT NULL,  
 `test_object_zip` NVARCHAR(5) NOT NULL,  
-`test_object_ispobox` BIT NOT NULL );"""
+`test_object_isPOBox` BIT NOT NULL );"""
         Assert.assertEquals(expected, actual)
-    }
-
-
-    @Test
-    fun can_build_ddl_2() {
-        val models = listOf(
-                Model.loadSchema(User5::class ),
-                Model.loadSchema(Member::class),
-                Model.loadSchema(Group::class )
-        )
-        val builder = SqlBuilder(Types(), null)
-        val ddls = models.map { builder.createTable(it) }
-        println(ddls)
     }
 }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Data_04_Entity_Service_Sqlite.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Data_04_Entity_Service_Sqlite.kt
@@ -18,8 +18,6 @@ import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 import slatekit.common.DateTime
-import slatekit.common.Field
-import slatekit.common.Id
 import slatekit.common.data.*
 import slatekit.common.utils.Random
 import slatekit.data.sql.vendors.sqliteIfNotExists
@@ -379,31 +377,31 @@ class Data_04_Entity_Service_Sqlite : Data_04_Entity_Service_MySql() {
             @property:Id()
             override val id: Int = 0,
 
-            @property:Field(length = 100, required = true)
+            @property:Column(length = 100, required = true)
             val email: String = "",
 
-            @property:Field(required = true)
+            @property:Column(required = true)
             val isActive: Boolean = false,
 
-            @property:Field(required = true)
+            @property:Column(required = true)
             val level: Int = 35,
 
-            @property:Field(required = true)
+            @property:Column(required = true)
             val salary: Double = 20.5,
 
-            @property:Field(required = true)
+            @property:Column(required = true)
             val createdAt: DateTime = DateTime.now(),
 
-            @property:Field(required = true)
+            @property:Column(required = true)
             val createdBy: Int = 0,
 
-            @property:Field(required = true)
+            @property:Column(required = true)
             val updatedAt: DateTime = DateTime.now(),
 
-            @property:Field(required = true)
+            @property:Column(required = true)
             val updatedBy: Int = 0,
 
-            @property:Field(length = 50, required = true)
+            @property:Column(length = 50, required = true)
             val uniqueId: String = Random.uuid()
     ) : EntityWithId<Int>, EntityUpdatable<Int, User> {
 
@@ -413,10 +411,10 @@ class Data_04_Entity_Service_Sqlite : Data_04_Entity_Service_MySql() {
 
 
     data class Group(
-            @property:Field(required = true)
+            @property:Column(required = true)
             val id: Int,
 
-            @property:Field(required = true, length = 30)
+            @property:Column(required = true, length = 30)
             val name: String
     ) : Entity<Int>, EntityUpdatable<Int, Group> {
 
@@ -427,13 +425,13 @@ class Data_04_Entity_Service_Sqlite : Data_04_Entity_Service_MySql() {
 
 
     data class Member(
-            @property:Field(required = true)
+            @property:Column(required = true)
             val id: Int,
 
-            @property:Field(required = true)
+            @property:Column(required = true)
             val groupId: Int,
 
-            @property:Field(required = true)
+            @property:Column(required = true)
             val userId: Int
     ) : Entity<Int>, EntityUpdatable<Int, Member> {
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/SampleEntity.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/SampleEntity.kt
@@ -3,15 +3,14 @@ package test.entities
 import org.threeten.bp.LocalDate
 import org.threeten.bp.LocalDateTime
 import org.threeten.bp.LocalTime
-import org.threeten.bp.ZonedDateTime
 import slatekit.common.DateTime
 import slatekit.common.DateTimes
-import slatekit.common.Field
-import slatekit.common.Id
 import slatekit.common.ids.UPID
 import slatekit.common.ids.UPIDs
 import slatekit.entities.EntityUpdatable
 import slatekit.entities.EntityWithId
+import slatekit.entities.Id
+import slatekit.entities.Column
 import test.setup.Address
 import test.setup.StatusEnum
 import java.util.*
@@ -20,52 +19,52 @@ data class SampleEntityImmutable(
         @property:Id()
         override val id: Long = 0L,
 
-        @property:Field(length = 30, required = true)
+        @property:Column(length = 30, required = true)
         val test_string: String = "",
 
-        @property:Field(length = 100, encrypt = true)
+        @property:Column(length = 100, encrypt = true)
         val test_string_enc: String = "",
 
-        @property:Field()
+        @property:Column()
         val test_bool: Boolean = false,
 
-        @property:Field()
+        @property:Column()
         val test_short: Short = 35,
 
-        @property:Field()
+        @property:Column()
         val test_int: Int = 35,
 
-        @property:Field()
+        @property:Column()
         val test_long: Long = 35,
 
-        @property:Field()
+        @property:Column()
         val test_float: Float = 20.5f,
 
-        @property:Field()
+        @property:Column()
         val test_double: Double = 20.5,
 
-        @property:Field()
+        @property:Column()
         val test_enum: StatusEnum = StatusEnum.Pending,
 
-        @property:Field()
+        @property:Column()
         val test_localdate: LocalDate = LocalDate.now(),
 
-        @property:Field()
+        @property:Column()
         val test_localtime: LocalTime = LocalTime.now(),
 
-        @property:Field()
+        @property:Column()
         val test_localdatetime: LocalDateTime = LocalDateTime.now(),
 
-        @property:Field()
+        @property:Column()
         val test_zoneddatetime: DateTime = DateTimes.now(),
 
-        @property:Field(length = 50, unique = true)
+        @property:Column(length = 50, unique = true)
         val test_uuid: UUID = UUID.randomUUID(),
 
-        @property:Field(length = 50, indexed = true)
+        @property:Column(length = 50, indexed = true)
         val test_uniqueId: UPID = UPIDs.create("usa"),
 
-        @property:Field()
+        @property:Column()
         val test_object: Address = Address("street 1", "city 1", "state 1", 1,"12345", true)
 
 ) : EntityWithId<Long>, EntityUpdatable<Long, SampleEntityImmutable> {
@@ -86,51 +85,51 @@ class SampleEntityMutable {
     @property:Id()
     var id: Long = 0L
 
-    @property:Field(length = 30, required = true)
+    @property:Column(length = 30, required = true)
     var test_string: String = ""
 
-    @property:Field(length = 100, encrypt = true)
+    @property:Column(length = 100, encrypt = true)
     var test_string_enc: String = ""
 
-    @property:Field()
+    @property:Column()
     var test_bool: Boolean = false
 
-    @property:Field()
+    @property:Column()
     var test_short: Short = 35
 
-    @property:Field()
+    @property:Column()
     var test_int: Int = 35
 
-    @property:Field()
+    @property:Column()
     var test_long: Long = 35
 
-    @property:Field()
+    @property:Column()
     var test_float: Float = 20.5f
 
-    @property:Field()
+    @property:Column()
     var test_double: Double = 20.5
 
-    @property:Field()
+    @property:Column()
     var test_enum: StatusEnum = StatusEnum.Pending
 
-    @property:Field()
+    @property:Column()
     var test_localdate: LocalDate = LocalDate.now()
 
-    @property:Field()
+    @property:Column()
     var test_localtime: LocalTime = LocalTime.now()
 
-    @property:Field()
+    @property:Column()
     var test_localdatetime: LocalDateTime = LocalDateTime.now()
 
-    @property:Field()
+    @property:Column()
     var test_zoneddatetime: DateTime = DateTimes.now()
 
-    @property:Field(length = 50, unique = true)
+    @property:Column(length = 50, unique = true)
     var test_uuid: UUID = UUID.randomUUID()
 
-    @property:Field(length = 50, indexed = true)
+    @property:Column(length = 50, indexed = true)
     var test_uniqueId: UPID = UPIDs.create("usa")
 
-    @property:Field()
+    @property:Column()
     var test_object: Address = Address("street 1", "city 1", "state 1", 1,"12345", true)
 }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/AuthorR.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/AuthorR.kt
@@ -1,0 +1,55 @@
+package test.meta
+
+import slatekit.common.DateTime
+import slatekit.common.utils.Random
+import slatekit.common.ids.UPID
+import slatekit.common.ids.UPIDs
+import slatekit.entities.EntityWithId
+import slatekit.meta.models.Id
+import slatekit.meta.models.Field
+import test.setup.StatusEnum
+import test.setup.UUIDSamples
+import java.util.*
+
+data class AuthorR(
+        @property:Id(generated = true)
+        override val id: Long = 0,
+
+        @property:Field(required = true)
+        val uuid: String            = Random.uuid(),
+
+        @property:Field(required = true)
+        val createdAt: DateTime = DateTime.now(),
+
+        @property:Field(required = true)
+        val createdBy: Long = 0,
+
+        @property:Field(required = true)
+        val updatedAt: DateTime = DateTime.now(),
+
+        @property:Field(required = true)
+        val updatedBy: Long = 0,
+
+        @property:Field(required = true)
+        val email:String = "",
+
+        @property:Field(required = true)
+        val isActive:Boolean = false,
+
+        @property:Field(required = true)
+        val age:Int = 35,
+
+        @property:Field(required = true)
+        val status: StatusEnum = StatusEnum.Pending,
+
+        @property:Field(required = true)
+        val salary:Double = 20.5,
+
+        @property:Field(required = true)
+        val uid: UUID = UUID.fromString(UUIDSamples.sampleUUID1),
+
+        @property:Field(required = true)
+        val shardId: UPID = UPIDs.parse(UUIDSamples.sampleUUID2)
+) : EntityWithId<Long> {
+        override fun isPersisted(): Boolean = id > 0
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/AuthorRNull.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/AuthorRNull.kt
@@ -1,9 +1,18 @@
 package test.meta
 
+import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.LocalTime
 import slatekit.common.DateTime
+import slatekit.common.DateTimes
+import slatekit.common.ids.UPID
+import slatekit.common.ids.UPIDs
+import slatekit.entities.EntityUpdatable
+import slatekit.entities.EntityWithId
 import slatekit.meta.models.Field
 import slatekit.meta.models.Id
 import test.setup.StatusEnum
+import java.util.*
 
 data class AuthorRNull(
         @property:Id()
@@ -26,4 +35,97 @@ data class AuthorRNull(
 
         @property:Field(required = false)
         val createdAt: DateTime? = null
+)
+
+
+data class SampleEntityImmutable(
+        @property:Id()
+        override val id: Long = 0L,
+
+        @property:Field(length = 30, required = true)
+        val test_string: String = "",
+
+        @property:Field(length = 100, encrypt = true)
+        val test_string_enc: String = "",
+
+        @property:Field()
+        val test_bool: Boolean = false,
+
+        @property:Field()
+        val test_short: Short = 35,
+
+        @property:Field()
+        val test_int: Int = 35,
+
+        @property:Field()
+        val test_long: Long = 35,
+
+        @property:Field()
+        val test_float: Float = 20.5f,
+
+        @property:Field()
+        val test_double: Double = 20.5,
+
+        @property:Field()
+        val test_enum: StatusEnum = StatusEnum.Pending,
+
+        @property:Field()
+        val test_localdate: LocalDate = LocalDate.now(),
+
+        @property:Field()
+        val test_localtime: LocalTime = LocalTime.now(),
+
+        @property:Field()
+        val test_localdatetime: LocalDateTime = LocalDateTime.now(),
+
+        @property:Field()
+        val test_zoneddatetime: DateTime = DateTimes.now(),
+
+        @property:Field(length = 50, unique = true)
+        val test_uuid: UUID = UUID.randomUUID(),
+
+        @property:Field(length = 50, indexed = true)
+        val test_uniqueId: UPID = UPIDs.create("usa"),
+
+        @property:Field()
+        val test_object: Address = Address("street 1", "city 1", "state 1", 1,"12345", true)
+
+) : EntityWithId<Long>, EntityUpdatable<Long, SampleEntityImmutable> {
+        override fun isPersisted(): Boolean = id > 0
+
+        /**
+         * sets the id on the entity and returns the entity with updated id.
+         * @param id
+         * @return
+         */
+        override fun withId(id: Long): SampleEntityImmutable {
+                return this.copy(id = id)
+        }
+}
+
+
+data class Address(
+
+        @property:Field(required = true, length = 40)
+        val addr   : String,
+
+
+        @property:Field(required = true, length = 30)
+        val city   : String,
+
+
+        @property:Field(required = true, length = 20)
+        val state  : String,
+
+
+        @property:Field(required = true)
+        val country: Int,
+
+
+        @property:Field(required = true, length = 5)
+        val zip    : String,
+
+
+        @property:Field(required = true)
+        val isPOBox: Boolean
 )

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/AuthorRNull.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/AuthorRNull.kt
@@ -1,10 +1,12 @@
-package test.setup
+package test.meta
 
 import slatekit.common.DateTime
-import slatekit.common.Field
+import slatekit.meta.models.Field
+import slatekit.meta.models.Id
+import test.setup.StatusEnum
 
 data class AuthorRNull(
-        @property:Field(required = false)
+        @property:Id()
         val id: Long ? = null,
 
         @property:Field(required = false)
@@ -17,7 +19,7 @@ data class AuthorRNull(
         val age:Int?  = null,
 
         @property:Field(required = false)
-        val status:StatusEnum = StatusEnum.Pending,
+        val status: StatusEnum = StatusEnum.Pending,
 
         @property:Field(required = false)
         val salary:Double? = null,

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/ModelTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/ModelTests.kt
@@ -8,7 +8,6 @@ import slatekit.common.ids.UPID
 import slatekit.meta.Reflector
 import slatekit.meta.models.FieldCategory
 import slatekit.meta.models.Model
-import test.entities.SampleEntityImmutable
 import test.setup.*
 import java.util.*
 import kotlin.reflect.KClass

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/ModelTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/ModelTests.kt
@@ -19,7 +19,7 @@ class ModelTests {
 
 
     @Test fun can_build_simple_model_from_reflection(){
-        val model = Model.loadSchema(AuthorR::class, AuthorR::id.name)
+        val model = Model.load(AuthorR::class, AuthorR::id.name)
         ensureAuthorModel(model)
     }
 
@@ -31,7 +31,7 @@ class ModelTests {
 
 
     @Test fun can_build_complex_model_from_schema(){
-        val model = Model.loadSchema(UserWithAddress::class, UserWithAddress::id.name)
+        val model = Model.load(UserWithAddress::class, UserWithAddress::id.name)
         val addrProp = model.fields.find { it.name == "addr" }
         Assert.assertTrue( addrProp != null)
         Assert.assertTrue( addrProp!!.model != null)
@@ -40,7 +40,7 @@ class ModelTests {
 
 
     @Test fun can_build_simple_model_with_nullable(){
-        val model = Model.loadSchema(AuthorRNull::class, AuthorRNull::id.name)
+        val model = Model.load(AuthorRNull::class, AuthorRNull::id.name)
         Assert.assertTrue(model.hasId)
         Assert.assertTrue(model.any)
         ensureField(model, "id"        , false, Long::class       )
@@ -54,7 +54,7 @@ class ModelTests {
 
 
     @Test fun can_build_simple_with_sub_objects(){
-        val model = Model.loadSchema(SampleEntityImmutable::class, SampleEntityImmutable::id.name)
+        val model = Model.load(SampleEntityImmutable::class, SampleEntityImmutable::id.name)
         Assert.assertTrue(model.hasId)
         Assert.assertTrue(model.any)
         fun ensure(name:String, storedAs:String, type:DataType, model: Model){

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/ReflectorTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/ReflectorTests.kt
@@ -31,6 +31,7 @@ import slatekit.db.Db
 import slatekit.meta.Reflector
 import slatekit.entities.Entities
 import slatekit.connectors.entities.AppEntContext
+import slatekit.entities.Column
 import slatekit.meta.KTypes
 import slatekit.results.Notice
 import slatekit.results.Success
@@ -288,7 +289,7 @@ class ReflectorTests : TestSupport {
             mem.annotations.forEach { ano -> println(ano) }
         }
         println("done")
-        val props = Reflector.getAnnotatedProps<Field>(User3::class, Field::class)
+        val props = Reflector.getAnnotatedProps<Column>(User3::class, Column::class)
         Assert.assertEquals(2, props.size)
         Assert.assertEquals(props[0].second?.name, "email")
         Assert.assertEquals(props[0].second?.required, true)

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/UserWithAddress.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/UserWithAddress.kt
@@ -1,32 +1,17 @@
-package test.setup
+package test.meta
 
-import slatekit.common.DateTime
-import slatekit.common.Field
-import slatekit.common.Id
-import slatekit.common.utils.Random
 import slatekit.common.ids.UPID
 import slatekit.common.ids.UPIDs
 import slatekit.entities.EntityWithId
+import slatekit.meta.models.Id
+import slatekit.meta.models.Field
+import test.setup.Address
+import test.setup.UUIDSamples
 import java.util.*
 
-data class AuthorR(
+data class UserWithAddress(
         @property:Id(generated = true)
-        override val id: Long = 0,
-
-        @property:Field(required = true)
-        val uuid: String            = Random.uuid(),
-
-        @property:Field(required = true)
-        val createdAt: DateTime = DateTime.now(),
-
-        @property:Field(required = true)
-        val createdBy: Long = 0,
-
-        @property:Field(required = true)
-        val updatedAt: DateTime = DateTime.now(),
-
-        @property:Field(required = true)
-        val updatedBy: Long = 0,
+        override val id: Long             = 0,
 
         @property:Field(required = true)
         val email:String = "",
@@ -38,10 +23,10 @@ data class AuthorR(
         val age:Int = 35,
 
         @property:Field(required = true)
-        val status:StatusEnum = StatusEnum.Pending,
-
-        @property:Field(required = true)
         val salary:Double = 20.5,
+
+        @property:Field(required = false)
+        val addr: Address? = null,
 
         @property:Field(required = true)
         val uid: UUID = UUID.fromString(UUIDSamples.sampleUUID1),

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/UserWithAddress.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/meta/UserWithAddress.kt
@@ -5,7 +5,6 @@ import slatekit.common.ids.UPIDs
 import slatekit.entities.EntityWithId
 import slatekit.meta.models.Id
 import slatekit.meta.models.Field
-import test.setup.Address
 import test.setup.UUIDSamples
 import java.util.*
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/Address.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/Address.kt
@@ -1,66 +1,32 @@
 package test.setup
 
-import slatekit.common.Field
-import slatekit.common.Id
-import slatekit.common.ids.UPID
-import slatekit.common.ids.UPIDs
-import slatekit.entities.EntityWithId
-import java.util.*
+import slatekit.entities.Column
 
 data class Address(
 
-        @property:Field(required = true, length = 40)
+        @property:Column(required = true, length = 40)
         val addr   : String,
 
 
-        @property:Field(required = true, length = 30)
+        @property:Column(required = true, length = 30)
         val city   : String,
 
 
-        @property:Field(required = true, length = 20)
+        @property:Column(required = true, length = 20)
         val state  : String,
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val country: Int,
 
 
-        @property:Field(required = true, length = 5)
+        @property:Column(required = true, length = 5)
         val zip    : String,
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val isPOBox: Boolean
 )
-
-
-data class UserWithAddress(
-        @property:Id(generated = true)
-        override val id: Long             = 0,
-
-        @property:Field(required = true)
-        val email:String = "",
-
-        @property:Field(required = true)
-        val isActive:Boolean = false,
-
-        @property:Field(required = true)
-        val age:Int = 35,
-
-        @property:Field(required = true)
-        val salary:Double = 20.5,
-
-        @property:Field(required = false)
-        val addr:Address? = null,
-
-        @property:Field(required = true)
-        val uid: UUID = UUID.fromString(UUIDSamples.sampleUUID1),
-
-        @property:Field(required = true)
-        val shardId: UPID = UPIDs.parse(UUIDSamples.sampleUUID2)
-) : EntityWithId<Long> {
-        override fun isPersisted(): Boolean = id > 0
-}
 
 
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/AuthorEnc.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/AuthorEnc.kt
@@ -1,55 +1,55 @@
 package test.setup
 
 import slatekit.common.DateTime
-import slatekit.common.Field
-import slatekit.common.Id
 import slatekit.common.ids.UPID
 import slatekit.common.ids.UPIDs
 import slatekit.common.utils.Random
 import slatekit.entities.EntityWithId
+import slatekit.entities.Id
+import slatekit.entities.Column
 import java.util.*
 
 data class AuthorEnc(
         @property:Id(generated = true)
         override val id: Long = 0,
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val uuid: String            = Random.uuid(),
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val createdAt: DateTime = DateTime.now(),
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val createdBy: Long = 0,
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val updatedAt: DateTime = DateTime.now(),
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val updatedBy: Long = 0,
 
-        @property:Field(required = true, encrypt = true)
+        @property:Column(required = true, encrypt = true)
         val email:String = "",
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val isActive:Boolean = false,
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val age:Int = 35,
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val status: StatusEnum = StatusEnum.Pending,
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val salary:Double = 20.5,
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val uid: UUID = UUID.fromString(UUIDSamples.sampleUUID1),
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val shardId: UPID = UPIDs.parse(UUIDSamples.sampleUUID2),
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val encmode: String = "a"
 ) : EntityWithId<Long> {
         override fun isPersisted(): Boolean = id > 0

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/AuthorW.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/AuthorW.kt
@@ -1,52 +1,53 @@
 package test.setup
 
 import slatekit.common.DateTime
-import slatekit.common.Field
 import slatekit.common.utils.Random
 import slatekit.common.ids.UPID
 import slatekit.common.ids.UPIDs
+import slatekit.entities.Column
 import slatekit.entities.EntityWithId
+import slatekit.entities.Id
 import java.util.*
 
 class AuthorW : EntityWithId<Long> {
     override fun isPersisted(): Boolean = id > 0
 
-    @property:Field(required = true)
+    @property:Id()
     override var id: Long = 0
 
-    @property:Field(required = true)
+    @property:Column(required = true)
     var uuid: String = Random.uuid()
 
-    @property:Field(required = true)
+    @property:Column(required = true)
     var createdAt: DateTime = DateTime.now()
 
-    @property:Field(required = true)
+    @property:Column(required = true)
     var createdBy: Long = 0
 
-    @property:Field(required = true)
+    @property:Column(required = true)
     var updatedAt: DateTime = DateTime.now()
 
-    @property:Field(required = true)
+    @property:Column(required = true)
     var updatedBy: Long = 0
 
-    @property:Field(required = true)
+    @property:Column(required = true)
     var email: String = ""
 
-    @property:Field(required = true)
+    @property:Column(required = true)
     var isActive: Boolean = false
 
-    @property:Field(required = true)
+    @property:Column(required = true)
     var age: Int = 35
 
-    @property:Field(required = true)
+    @property:Column(required = true)
     var status:StatusEnum = StatusEnum.Pending
 
-    @property:Field(required = true)
+    @property:Column(required = true)
     var salary: Double = 20.5
 
-    @property:Field(required = true)
+    @property:Column(required = true)
     var uid: UUID = UUID.fromString(UUIDSamples.sampleUUID1)
 
-    @property:Field(required = true)
+    @property:Column(required = true)
     var shardId: UPID = UPIDs.parse(UUIDSamples.sampleUUID2)
 }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/Movie.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/Movie.kt
@@ -3,53 +3,53 @@ package test.setup
 
 import slatekit.common.DateTime
 import slatekit.common.DateTimes
-import slatekit.common.Field
-import slatekit.common.Id
+import slatekit.entities.Column
 import slatekit.entities.EntityWithId
+import slatekit.entities.Id
 
 data class Movie(
         @property:Id()
         override val id :Long = 0L,
 
 
-        @property:Field(required = true, length = 50)
+        @property:Column(required = true, length = 50)
         val title :String = "",
 
 
-        @property:Field(length = 20)
+        @property:Column(length = 20)
         val category :String = "",
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val playing :Boolean = false,
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val cost:Int,
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val rating: Double,
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val released: DateTime,
 
 
         // These are the timestamp and audit fields.
-        @property:Field(required = true)
+        @property:Column(required = true)
         val createdAt : DateTime = DateTime.now(),
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val createdBy :Long  = 0,
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val updatedAt : DateTime =  DateTime.now(),
 
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val updatedBy :Long  = 0
 )
     : EntityWithId<Long> {

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/UserNormal.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/setup/UserNormal.kt
@@ -14,11 +14,7 @@ package test.setup
 
 import slatekit.common.utils.Random
 import slatekit.common.DateTime
-import slatekit.common.Field
-import slatekit.common.Id
-import slatekit.entities.Entity
-import slatekit.entities.EntityUpdatable
-import slatekit.entities.EntityWithId
+import slatekit.entities.*
 
 /**
  * Created by kishorereddy on 5/23/17.
@@ -45,10 +41,10 @@ data class User(
 
 
 data class Group(
-        @property:Field(required = true)
+        @property:Id()
         val id: Long,
 
-        @property:Field(required = true, length = 30)
+        @property:Column(required = true, length = 30)
         val name: String
 ) : Entity<Long>, EntityUpdatable<Long, Group> {
 
@@ -59,13 +55,13 @@ data class Group(
 
 
 data class Member(
-        @property:Field(required = true)
+        @property:Column(required = true)
         val id: Long,
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val groupId: Long,
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val userId: Long
 ) : Entity<Long>, EntityUpdatable<Long, Member> {
 
@@ -99,10 +95,10 @@ class UserNormal2(var email: String, var name: String) {
 
 data class User3(
 
-        @property:Field(name = "email", desc = "email address", required = true, example = "clark@metro.com")
+        @property:Column(name = "email", desc = "email address", required = true, example = "clark@metro.com")
         val email: String,
 
-        @property:Field(desc = "full api", required = false, example = "clark kent")
+        @property:Column(desc = "full api", required = false, example = "clark kent")
         val name: String
 ) {
 
@@ -133,31 +129,31 @@ data class User5(
         @property:Id()
         override val id: Long = 0,
 
-        @property:Field(length = 100, required = true)
+        @property:Column(length = 100, required = true)
         val email: String = "",
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val isActive: Boolean = false,
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val level: Int = 35,
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val salary: Double = 20.5,
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val createdAt: DateTime = DateTime.now(),
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val createdBy: Long = 0,
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val updatedAt: DateTime = DateTime.now(),
 
-        @property:Field(required = true)
+        @property:Column(required = true)
         val updatedBy: Long = 0,
 
-        @property:Field(length = 50, required = true)
+        @property:Column(length = 50, required = true)
         val uniqueId: String = Random.uuid()
 ) : EntityWithId<Long>, EntityUpdatable<Long, User5> {
 

--- a/src/lib/kotlin/slatekit/src/main/resources/env.conf
+++ b/src/lib/kotlin/slatekit/src/main/resources/env.conf
@@ -27,9 +27,9 @@ app.tags     = slate,shell,cli
 app.examples = sampleapp -env=dev -log.level=debug -region='ny' -enc=false
 
 slatekit.tag = "v2"
-slatekit.version = 2.2.0
-slatekit.version.beta = 2.2.0
-slatekit.version.cli = 2.2.0
+slatekit.version = 2.2.1
+slatekit.version.beta = 2.2.1
+slatekit.version.cli = 2.2.1
 kotlin.version = 1.3.21
 generation.source = usr://slatekit/generator/templates
 generation.output = usr://slatekit/generator/gen

--- a/src/lib/kotlin/slatekit/src/main/resources/env.conf
+++ b/src/lib/kotlin/slatekit/src/main/resources/env.conf
@@ -27,9 +27,9 @@ app.tags     = slate,shell,cli
 app.examples = sampleapp -env=dev -log.level=debug -region='ny' -enc=false
 
 slatekit.tag = "v2"
-slatekit.version = 2.2.1
-slatekit.version.beta = 2.2.1
-slatekit.version.cli = 2.2.1
+slatekit.version = 2.3.0
+slatekit.version.beta = 2.3.0
+slatekit.version.cli = 2.3.0
 kotlin.version = 1.3.21
 generation.source = usr://slatekit/generator/templates
 generation.output = usr://slatekit/generator/gen

--- a/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/api/files/src/SampleModel.txt
+++ b/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/api/files/src/SampleModel.txt
@@ -1,7 +1,7 @@
 package ${app.package}.models
 
 import slatekit.common.DateTime
-import slatekit.common.Field
+import slatekit.meta.models.Field
 
 data class SampleMovie(
         val id :Long = 0L,

--- a/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/cli/files/src/SampleModel.txt
+++ b/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/cli/files/src/SampleModel.txt
@@ -1,7 +1,7 @@
 package ${app.package}.models
 
 import slatekit.common.DateTime
-import slatekit.common.Field
+import slatekit.meta.models.Field
 
 data class SampleMovie(
         val id :Long = 0L,


### PR DESCRIPTION
## Overview
Misc fixes related to logs and Data modules
Several **cosmetic** changes due to some renamed/moved fields.

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
1. Updated Logback to 1.2.3

## Design
1. Entities: **Id** annotation moved to entities 
2. Entities: **Field** annotation replaced with **Column** to align with JPA
3. Entities: Modules/Entities API fixed to support installations
4. Logs: Minor fix for filtering on the log level
5. Logs: Upgrade logback to 1.2.3
6. Logs: Added support for `structured logging` via overload methods taking in key/value pairs


## Notes
n/a

## Pending
n/a

## Tests
1. Unit-tests changed to handle rename of entity fields from `field` to `column`
