### PR TITLE
FIX: Handling of sub objects with same name + performance fix

### DIFF
--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Data_02_Mappers_Encode.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/Data_02_Mappers_Encode.kt
@@ -55,6 +55,22 @@ class Data_02_Mappers_Encode {
 
 
     @Test
+    fun can_encode_model_immutable_same_values() {
+        val model = Schema.load(SampleEdgeCases::class)
+        val meta = Meta<Long, SampleEdgeCases>(LongId { m -> m.id }, Table("sample1"))
+        val mapper = EntityEncoder<Long, SampleEdgeCases>(model, meta, settings = EntitySettings(false), encryptor = EntitySetup.enc)
+        val sample = SampleEdgeCases(1, "root")
+        val values = mapper.encode(sample, DataAction.Create, EntitySetup.enc)
+        Assert.assertEquals(4, values.size)
+        Assert.assertEquals("`name`", values[0].name)
+        Assert.assertEquals("root", values[0].value)
+        Assert.assertEquals("`item_name`", values[2].name)
+        Assert.assertEquals("sub1", values[2].value)
+
+    }
+
+
+    @Test
     fun can_encode_model_mutable() {
         val model = Schema.load(SampleEntityMutable::class)
         val meta = Meta<Long, SampleEntityMutable>(LongId { m -> m.id }, Table("sample1"))

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/SampleEntity.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/entities/SampleEntity.kt
@@ -15,6 +15,29 @@ import test.setup.Address
 import test.setup.StatusEnum
 import java.util.*
 
+data class SampleEdgeCases(
+        @property:Id()
+        val id: Long = 0L,
+
+        @property:Column(length = 30, required = true)
+        val name: String = "",
+
+        @property:Column()
+        val active: Boolean = true,
+
+        @property:Column()
+        val item: SampleSubobject = SampleSubobject("sub1", "123")
+)
+
+data class SampleSubobject(
+        @property:Column(length = 30, required = true)
+        val name: String = "",
+
+        @property:Column()
+        val uuid: String = ""
+)
+
+
 data class SampleEntityImmutable(
         @property:Id()
         override val id: Long = 0L,


### PR DESCRIPTION
## FIX Data mapper
- Handle sub-objects with same name 
- Handle getting value using already available property ( if available ) for performance improvement
