### PR TITLE
EMAIL : Update to SendGrid latest API + Misc fixes

### DIFF
--- a/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppBuilder.kt
+++ b/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppBuilder.kt
@@ -40,7 +40,7 @@ object AppBuilder {
      *
      * @return
      */
-    fun dbs(cls:Class<*>, conf: Conf): Connections = Connections.of(conf.dbCon("db"))
+    fun dbs(conf: Conf): Connections = Connections.of(conf.dbCon("db"))
 
     /**
      * builds all the info for this application including its
@@ -141,7 +141,7 @@ object AppBuilder {
     /**
      * Gets the build info file
      */
-    fun build(cls:Class<*>, args: Args, loc:Uri): Build {
+    fun build(cls:Class<*>, loc:Uri): Build {
         val result = Tries.of {
             val uri = loc.combine("build.conf")
             val props = Props.fromUri(cls, uri)
@@ -169,7 +169,7 @@ object AppBuilder {
      * 5. dirs ( defaults )
      */
     fun context(cls:Class<*>, inputs: AppUtils.AppInputs, enc: Encryptor?, logs: Logs?): AppContext {
-        val build = build(cls, inputs.args, inputs.loc)
+        val build = build(cls, inputs.loc)
         val args = inputs.args
         val env = inputs.envs
 

--- a/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppRunner.kt
+++ b/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppRunner.kt
@@ -70,7 +70,7 @@ object AppRunner {
         // STEP 5: Build App - Create App using supplied lambda and context
         // STEP 6: Run App   - Finally run the application with workflow ( init, exec, end )
         val result = argsResult.then { args -> AppHelp.process(cls, source, rawArgs.toList(), args, about, schema) }
-            .then { args    -> Tries.of { AppUtils.context(cls, args, envs, about, schema ?: AppBuilder.schema(), enc, logs, source) } }
+            .then { args    -> Tries.of { AppUtils.context(cls, args, envs, enc, logs, source) } }
             .then { context -> Tries.of { context.copy(args = ArgsSchema.transform(schema, context.args)) } }
             .then { context -> validate(context.args, schema).map { context } }
             .then { context -> Tries.of { builder(context) } }

--- a/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppUtils.kt
+++ b/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppUtils.kt
@@ -61,12 +61,12 @@ object AppUtils {
         }
     }
 
-    fun context(cls:Class<*>, args: Args, envs: Envs, about: About, schema: ArgsSchema, enc: Encryptor?, logs: Logs?, confSource:Alias = Alias.Jar): AppContext {
-        val inputs = inputs(cls, args, envs, about, schema, enc, logs, confSource)
+    fun context(cls:Class<*>, args: Args, envs: Envs, enc: Encryptor?, logs: Logs?, confSource:Alias = Alias.Jar): AppContext {
+        val inputs = inputs(cls, args, envs, enc, confSource)
         return AppBuilder.context(cls, inputs, enc, logs)
     }
 
-    private fun inputs(cls:Class<*>, args: Args, envs: Envs, about: About, schema: ArgsSchema, enc: Encryptor?, logs: Logs?, alias:Alias = Alias.Jar): AppInputs {
+    private fun inputs(cls:Class<*>, args: Args, envs: Envs, enc: Encryptor?, alias:Alias = Alias.Jar): AppInputs {
         // We need to determine where the "env.conf" is loaded from.
         // The location is defaulted to load from jars but can be explicitly supplied in args
         // or specified in the "conf.dirs" config setting in the env.conf file

--- a/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppValues.kt
+++ b/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppValues.kt
@@ -58,6 +58,6 @@ class AppValues(val args: Args, val conf: Conf) {
         return if (!arg.isNullOrEmpty())
             arg
         else
-            cfg ?: finalDefaultValue
+            cfg
     }
 }

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/envs/EnvMode.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/envs/EnvMode.kt
@@ -58,12 +58,12 @@ sealed class EnvMode(val name: String) {
          */
         @JvmStatic
         fun parse(text:String): EnvMode = when(text.trim().toLowerCase()) {
-            EnvMode.Dev.name -> EnvMode.Dev
-            EnvMode.Qat.name -> EnvMode.Qat
-            EnvMode.Uat.name -> EnvMode.Uat
-            EnvMode.Dis.name -> EnvMode.Dis
-            EnvMode.Pro.name -> EnvMode.Pro
-            else             -> EnvMode.Other(text)
+            Dev.name -> Dev
+            Qat.name -> Qat
+            Uat.name -> Uat
+            Dis.name -> Dis
+            Pro.name -> Pro
+            else     -> Other(text)
         }
     }
 }

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/envs/Envs.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/envs/Envs.kt
@@ -113,10 +113,13 @@ data class Envs(val all: List<Env>, val current: Env) : EnvSupport {
          * /resources/env.conf     ( common      config )
          * /resources/env.loc.conf ( local       config )
          * /resources/env.dev.conf ( development config )
-         * /resources/env.qa1.conf ( qa1         config )
-         * /resources/env.qa2.conf ( qa2         config )
+         * /resources/env.qat.conf ( qat         config )
          * /resources/env.stg.conf ( staging     config )
          * /resources/env.pro.conf ( production  config )
+         *
+         * e.g. For multiple QAT environments ( qa1, qa2 )
+         * /resources/env.qa1.conf ( qa1         config )
+         * /resources/env.qa2.conf ( qa2         config )
          *
          * @return
          */
@@ -125,8 +128,7 @@ data class Envs(val all: List<Env>, val current: Env) : EnvSupport {
             val envs = Envs(listOf(
                     Env("loc", EnvMode.Dev, desc = "Dev environment (local)"),
                     Env("dev", EnvMode.Dev, desc = "Dev environment (shared)"),
-                    Env("qa1", EnvMode.Qat, desc = "QA environment  (current release)"),
-                    Env("qa2", EnvMode.Qat, desc = "QA environment  (last release)"),
+                    Env("qat", EnvMode.Qat, desc = "QA environment  (current release)"),
                     Env("stg", EnvMode.Uat, desc = "STG environment (demo)"),
                     Env("pro", EnvMode.Pro, desc = "LIVE environment")
             ))

--- a/src/lib/kotlin/slatekit-data/src/main/kotlin/slatekit/data/encoders/Enums.kt
+++ b/src/lib/kotlin/slatekit-data/src/main/kotlin/slatekit/data/encoders/Enums.kt
@@ -22,14 +22,19 @@ open class EnumEncoder(val dataType:DataType = DataType.DTEnum) : SqlEncoder<Enu
 
     override fun convert(name:String, value: EnumLike?): Value {
         val finalValue = when(dataType){
-            DataType.DTInt -> value?.let { it.value }
+            DataType.DTInt  -> value?.let { it.value }
+            DataType.DTLong -> value?.let { it.value.toLong() }
             else -> value
         }
         return Value(name, dataType, finalValue, encode(value))
     }
 
     fun decode(record: Record, name: String, dataCls: KClass<*>): EnumLike? {
-        val enumInt = record.getInt(name)
+        val enumInt = when(dataType) {
+            DataType.DTInt -> record.getInt(name)
+            DataType.DTLong -> record.getLong(name).toInt()
+            else -> record.getInt(name)
+        }
         val enumValue = Reflector.getEnumValue(dataCls, enumInt)
         return enumValue
     }

--- a/src/lib/kotlin/slatekit-data/src/main/kotlin/slatekit/data/sql/vendors/Sqlite.kt
+++ b/src/lib/kotlin/slatekit-data/src/main/kotlin/slatekit/data/sql/vendors/Sqlite.kt
@@ -69,6 +69,7 @@ open class SqliteEncoders<TId, T>(utc:Boolean) : Encoders<TId, T>(utc) where TId
     override val zonedDateTimes     = ZonedDateTimeEncoder(DataType.DTLong, utc)
     override val dateTimes          = DateTimeEncoder(DataType.DTLong, utc)
     override val instants           = InstantEncoder(DataType.DTLong)
+    override val enums              = EnumEncoder(DataType.DTInt)
 }
 
 

--- a/src/lib/kotlin/slatekit-http/src/main/kotlin/slatekit/http/HttpCoroutine.kt
+++ b/src/lib/kotlin/slatekit-http/src/main/kotlin/slatekit/http/HttpCoroutine.kt
@@ -40,7 +40,9 @@ suspend fun awaitHttpTry(callback: (HttpRPC.HttpRPCResult) -> Unit ) : Try<Respo
 suspend fun awaitHttpOutcome(callback: (HttpRPC.HttpRPCResult) -> Unit ) : Outcome<Response> {
     return suspendCoroutine { cont ->
         callback(object : HttpRPC.HttpRPCResult {
-            override fun onSuccess(result: Response) = cont.resume(Outcomes.success(result))
+            override fun onSuccess(result: Response) {
+                cont.resume(Outcomes.success(result))
+            }
             override fun onFailure(e: Exception?) {
                 e?.let { cont.resume(Outcomes.errored(e)) }
             }

--- a/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/builders/Options.kt
+++ b/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/builders/Options.kt
@@ -31,7 +31,7 @@ object Options : OptionsBuilder {
      * Build a Notice<T> ( type alias ) for Result<T,String> using the supplied function
      */
     @JvmStatic
-    inline fun <T> of(f: () -> T): Option<T> = build(f, { e -> Codes.ERRORED })
+    inline fun <T> of(f: () -> T): Option<T> = build(f, { _ -> Codes.ERRORED })
 
     /**
      * Build a Result<T,E> using the supplied callback and error handler

--- a/src/lib/kotlin/slatekit-tests/src/main/resources/env.qat.conf
+++ b/src/lib/kotlin/slatekit-tests/src/main/resources/env.qat.conf
@@ -6,7 +6,7 @@ test_text = abc
 test_date = 20170609
 test_long = 10
 test_doub = 20.3
-test_stri = env qa1
+test_stri = env qat
 test_ints = 1,22,33,44
 test_maps = a=1,b=22,c=33,d=44
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/app/AppLoaderTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/app/AppLoaderTests.kt
@@ -48,18 +48,10 @@ class AppLoaderTests  {
     }
 
     @Test
-    fun can_select_and_use_env_qa1() {
+    fun can_select_and_use_env_qat() {
         run(
-                arrayOf("-env='qa1'"),
-                ConfigValueTest("qa1", "env qa1", 3, 20.3),
-                Codes.SUCCESS
-        )
-    }
-
-    @Test
-    fun can_select_and_use_env_qa2() {
-        run(arrayOf("-env='qa2'"),
-                ConfigValueTest("qa2", "env qa2", 4, 20.4),
+                arrayOf("-env='qat'"),
+                ConfigValueTest("qat", "env qat", 3, 20.3),
                 Codes.SUCCESS
         )
     }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/EnvTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/EnvTests.kt
@@ -44,8 +44,7 @@ class EnvTests {
         val envs = Envs.defaults()
         ensureMatch( envs, "loc", EnvMode.Dev , "Dev environment (local)" )
         ensureMatch( envs, "dev", EnvMode.Dev , "Dev environment (shared)" )
-        ensureMatch( envs, "qa1", EnvMode.Qat  , "QA environment  (current release)" )
-        ensureMatch( envs, "qa2", EnvMode.Qat  , "QA environment  (last release)" )
+        ensureMatch( envs, "qat", EnvMode.Qat  , "QA environment  (current release)" )
         ensureMatch( envs, "stg", EnvMode.Uat , "STG environment (demo)" )
         ensureMatch( envs, "pro", EnvMode.Pro, "LIVE environment" )
     }
@@ -62,9 +61,9 @@ class EnvTests {
 
     @Test fun default_envs_can_select_environment() {
         val envAll = Envs.defaults()
-        val envs = envAll.select("qa1")
+        val envs = envAll.select("qat")
         Assert.assertTrue( envs.current != null )
-        Assert.assertTrue( envs.name == "qa1")
+        Assert.assertTrue( envs.name == "qat")
         Assert.assertTrue( envs.env == EnvMode.Qat.name )
         Assert.assertTrue( envs.isQat )
     }
@@ -72,7 +71,7 @@ class EnvTests {
 
     @Test fun default_envs_can_validate_env_against_defaults() {
         val envAll = Envs.defaults()
-        Assert.assertTrue( envAll.isValid("qa1") )
+        Assert.assertTrue( envAll.isValid("qat") )
         Assert.assertTrue( !envAll.isValid("abc") )
     }
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/NotificationTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/NotificationTests.kt
@@ -1,0 +1,38 @@
+package test.core
+
+import kotlinx.coroutines.runBlocking
+import okio.Buffer
+import org.junit.Assert
+import org.junit.Test
+import slatekit.common.conf.Config
+import slatekit.notifications.email.EmailMessage
+import slatekit.notifications.email.SendGrid
+import test.TestApp
+
+//import slatekit.providers.metrics.dropwizard.MetricService
+
+
+class NotificationTests {
+
+    @Test
+    fun can_build_sendgrid() {
+        val conf = Config.of(TestApp::class.java, "usr://.slatekit/common/conf/email.conf")
+        val key = conf.apiLogin("email")
+        val email = SendGrid(key)
+        val req = email.build(EmailMessage("jl@dc.com", "Series 123", "The totality", true))
+        runBlocking {
+            req.onSuccess {
+                Assert.assertEquals("https://api.sendgrid.com/v3/mail/send", it.url().toString())
+                Assert.assertEquals("POST", it.method())
+                Assert.assertTrue(it.header("Authorization").isNotEmpty())
+
+                val expected = """{"personalizations":[{"to":[{"name":"","email":"jl@dc.com"}]}],"subject":"Series 123","from":{"name":"slatekit","email":"support@slatekit.com"},"content":[{"type":"text\/html","value":"The totality"}]}"""
+                val buffer = Buffer()
+                it.body()?.writeTo(buffer)
+                val content = buffer.readUtf8()
+                //println(content)
+                Assert.assertEquals(expected, content)
+            }
+        }
+    }
+}

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/NotificationTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/NotificationTests.kt
@@ -5,8 +5,10 @@ import okio.Buffer
 import org.junit.Assert
 import org.junit.Test
 import slatekit.common.conf.Config
+import slatekit.common.info.ApiLogin
 import slatekit.notifications.email.EmailMessage
 import slatekit.notifications.email.SendGrid
+import slatekit.notifications.sms.TwilioSms
 import test.TestApp
 
 //import slatekit.providers.metrics.dropwizard.MetricService
@@ -16,10 +18,11 @@ class NotificationTests {
 
     @Test
     fun can_build_sendgrid() {
-        val conf = Config.of(TestApp::class.java, "usr://.slatekit/common/conf/email.conf")
-        val key = conf.apiLogin("email")
-        val email = SendGrid(key)
-        val req = email.build(EmailMessage("jl@dc.com", "Series 123", "The totality", true))
+        //val conf = Config.of(TestApp::class.java, "usr://.slatekit/common/conf/email.conf")
+        //val key = conf.apiLogin("email")
+        val key = ApiLogin("support@slatekit.com", "slatekit", "pswd", "dev", "test")
+        val service = SendGrid(key)
+        val req = service.build(EmailMessage("jl@dc.com", "Series 123", "The totality", true))
         runBlocking {
             req.onSuccess {
                 Assert.assertEquals("https://api.sendgrid.com/v3/mail/send", it.url().toString())
@@ -30,9 +33,19 @@ class NotificationTests {
                 val buffer = Buffer()
                 it.body()?.writeTo(buffer)
                 val content = buffer.readUtf8()
-                //println(content)
                 Assert.assertEquals(expected, content)
             }
+        }
+    }
+
+    //@Test
+    fun can_build_twilio() {
+        val conf = Config.of(TestApp::class.java, "usr://.slatekit/common/conf/sms.conf")
+        val key = conf.apiLogin("sms")
+        val service = TwilioSms(key)
+        runBlocking {
+            val req = service.send("Testing from kotlin", "us", "123456789")
+            println(req)
         }
     }
 }

--- a/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/conf/files/env.qat.conf
+++ b/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/conf/files/env.qat.conf
@@ -1,7 +1,7 @@
 
 # environment info
-env.name = "qa1"
-env.mode = "qa"
+env.name = "qat"
+env.mode = "qat"
 env.desc = "shared quality assurance environment 1"
 
 


### PR DESCRIPTION
## Overview
Upgrade to the latest version of the SendGrid API for sending emails.
The Email is a simple email sender that uses sendgrid underneath as the email provider. 

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
n/a

## Design
1. Using their API V3 : https://api.sendgrid.com/v3/mail/send
2. Env: Env component replaces the prior environments `qa1, qa2` with simply `qat`
3. Lint: removed misc lint warnings
4. Sqlite: For enums, supporting conversion of enums to both int and long

## Notes
n/a

## Pending
n/a

## Tests
n/a
