### PR TITLE
PATCH: API Responses

### DIFF
--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/Sampler.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/Sampler.kt
@@ -3,7 +3,7 @@ package slatekit.samples
 
 fun main(args: Array<String>) {
 //    Samples.app(args)
-    Samples.cli(args)
+      Samples.app(args)
 //    Samples.api(args)
 //    Samples.job(arrayOf("-sample=onetime"))
 }

--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/apis/SampleAPI.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/common/apis/SampleAPI.kt
@@ -26,6 +26,7 @@ import slatekit.samples.common.models.Movie
  * ROUTE                | SOURCE        | PURPOSE
  * samples/all/about    , CLI + WEB     , 0 params: get version info
  * samples/all/greet    , CLI + WEB     , 1 param : simple hello world greeting
+ * samples/all/outcome  , CLI + WEB     , 1 param : shows how to model success and failure
  * samples/all/inc      , CLI + WEB     , 0 params: increment a accumulator
  * samples/all/add      , CLI + WEB     , 1 param : add to a accumulator
  * samples/all/value    , CLI + WEB     , get value of the counter
@@ -94,6 +95,27 @@ class SampleAPI(context: Context) : ApiBase(context) {
     @Action(desc = "simple hello world greeting")
     fun greet(greeting: String): String {
         return "$greeting back"
+    }
+
+
+    /*
+     Sample acton to show how to model success/failure values
+     Examples:
+     CLI: samples.all.about
+     WEB: curl -X POST http://localhost:5000/api/samples/all/about
+     */
+    @Action(desc = "show how to model success and failure")
+    fun outcome(name:String): Outcome<Int> {
+        return when(name.toLowerCase()){
+            "succeeded" -> Outcomes.success(1)
+            "pending"   -> Outcomes.pending(2)
+            "denied"    -> Outcomes.denied("Sample denied error")
+            "ignored"   -> Outcomes.ignored("Sample ignored error")
+            "invalid"   -> Outcomes.invalid("Sample invalid error")
+            "errored"   -> Outcomes.errored("Sample expected error")
+            "unknown"   -> Outcomes.unexpected("Sample unexpected error")
+            else       -> Outcomes.unexpected("Sample unexpected error")
+        }
     }
 
 

--- a/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppHelp.kt
+++ b/src/lib/kotlin/slatekit-app/src/main/kotlin/slatekit/app/AppHelp.kt
@@ -138,9 +138,7 @@ class AppHelp(val info: Info, val args: ArgsSchema, val envs: Envs = Envs.defaul
     }
 
     private fun version() {
-        wrap {
-            println("version : " + info.build.version)
-        }
+        println("version : " + info.build.version)
     }
 
     private fun options() {

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/checks/Patterns.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/checks/Patterns.kt
@@ -23,7 +23,7 @@ data class Pattern(val pattern: String)
   * Named regex pattern
   */
 object Patterns {
-    @JvmField val email = Pattern("""(\w+)@([\w\.]+)""")
+    @JvmField val email = Pattern("""([\w\.\-\_]+)@([\w\.\-\_]+)""")
     @JvmField val alpha = Pattern("""^[a-zA-Z]*$""")
     @JvmField val alphaUpperCase = Pattern("""^[A-Z]*$""")
     @JvmField val alphaLowerCase = Pattern("""^[a-z]*$""")

--- a/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/Status.kt
+++ b/src/lib/kotlin/slatekit-result/src/main/kotlin/slatekit/results/Status.kt
@@ -69,18 +69,19 @@ interface Status {
             if (msg != null && rawStatus != null) return rawStatus.copyDesc(msg) as T
             return status
         }
-        
+
         fun toType(status:Status):String {
-            return when(status) {
-                is Passed.Succeeded -> Passed::Succeeded.name
-                is Passed.Pending -> Passed::Pending.name
-                is Failed.Denied  -> Failed::Denied .name
-                is Failed.Ignored -> Failed::Ignored.name
-                is Failed.Invalid -> Failed::Invalid.name
-                is Failed.Errored -> Failed::Errored.name
-                is Failed.Unknown -> Failed::Unknown.name
+            val name:String = when(status) {
+                is Passed.Succeeded -> "Succeeded"
+                is Passed.Pending   -> "Pending"
+                is Failed.Denied    -> "Denied"
+                is Failed.Ignored   -> "Ignored"
+                is Failed.Invalid   -> "Invalid"
+                is Failed.Errored   -> "Errored"
+                is Failed.Unknown   -> "Unknown"
                 else -> Failed::Unknown.name
             }
+            return name
         }
     }
 }

--- a/src/lib/kotlin/slatekit-serialization/src/main/kotlin/slatekit/serialization/responses/ResponseDecoder.kt
+++ b/src/lib/kotlin/slatekit-serialization/src/main/kotlin/slatekit/serialization/responses/ResponseDecoder.kt
@@ -36,11 +36,12 @@ object ResponseDecoder {
                 Success(value, status)
             }
             false -> {
+                val status = decodeStatus(root) as Failed
                 if (root.containsKey("errs")) {
                     val errList = decodeErrs(root)
-                    Outcomes.errored<T>(errList)
+                    Failure<Err>(errList, status)
                 } else {
-                    Outcomes.errored<T>("unable to parse result")
+                    Failure<Err>(Err.of("unable to parse result"), status)
                 }
             }
         }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/ValidationTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/common/ValidationTests.kt
@@ -121,6 +121,9 @@ class ValidationTests {
         Assert.assertTrue( !isEmail("@amazonian.com"))
         Assert.assertTrue( !isEmail("wonderwoman_amazonian.com"))
         Assert.assertTrue(  isEmail("wonderwoman@amazonian.com"))
+        Assert.assertTrue(  isEmail("wonder.woman@amazon-ian.com"))
+        Assert.assertTrue(  isEmail("wonder-woman@amazon_ian.com"))
+        Assert.assertTrue(  isEmail("wonder_woman@amazonian.com"))
     }
 
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/ResultBuilderTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/results/ResultBuilderTests.kt
@@ -1,6 +1,7 @@
 package test.results
 import org.junit.Assert
 import org.junit.Test
+import slatekit.meta.kClass
 import slatekit.results.*
 import slatekit.results.Codes
 import slatekit.results.builders.OutcomeBuilder
@@ -110,6 +111,7 @@ class ResultBuilderTests : ResultTestSupport, OutcomeBuilder {
             	"success": false,
             	"meta": null,
             	"name": "CONFLICT",
+                "type": "Errored",
             	"tag": null,
             	"value": null,
             	"desc": "Conflict"
@@ -117,6 +119,9 @@ class ResultBuilderTests : ResultTestSupport, OutcomeBuilder {
         """.trimIndent()
         val result = ResponseDecoder.outcome(json, Int::class.java) { Outcomes.success(42) }
         Assert.assertFalse(result.success)
+        Assert.assertEquals( Codes.CONFLICT.name, result.status.name)
+        Assert.assertEquals( Codes.CONFLICT.desc, result.status.desc)
+        Assert.assertEquals( Codes.CONFLICT.code, result.status.code)
         result.onFailure {err ->
             Assert.assertTrue( err is Err.ErrorList)
             Assert.assertTrue( (err as Err.ErrorList).errors[0] is Err.ErrorField)
@@ -179,5 +184,17 @@ class ResultBuilderTests : ResultTestSupport, OutcomeBuilder {
         Assert.assertEquals("REGISTERED", result.status.name)
         Assert.assertEquals(900001, result.status.code)
         Assert.assertEquals("Registration successful", result.status.desc)
+    }
+
+
+    @Test
+    fun can_get_type_of_status() {
+        Assert.assertEquals("Succeeded" , Status.toType(Codes.SUCCESS))
+        Assert.assertEquals("Pending"   , Status.toType(Codes.PENDING))
+        Assert.assertEquals("Denied"    , Status.toType(Codes.DENIED))
+        Assert.assertEquals("Ignored"   , Status.toType(Codes.IGNORED))
+        Assert.assertEquals("Invalid"   , Status.toType(Codes.INVALID))
+        Assert.assertEquals("Errored"   , Status.toType(Codes.ERRORED))
+        Assert.assertEquals("Unknown"   , Status.toType(Codes.UNEXPECTED))
     }
 }


### PR DESCRIPTION
## Overview
Minor patch to fix API responses to serialize the proper category of success/failure.

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
n/a

## Design
1. Serialize Passed/Failed subclass types
2. Fix Email regex ( keeping it simple for now )


## Notes
n/a

## Pending
n/a

## Tests
Unit-tests added
