### PR TITLE
PATCH: Notification components

### DIFF
--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/types/Country.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/types/Country.kt
@@ -16,10 +16,11 @@ package slatekit.common.types
 /**
  * Represents a country with iso code, name, and phone codes for sms features
  *
- * @param iso2 : 2 char iso code
- * @param iso3 : 3 char iso code
- * @param phoneCode : international dialing code
- * @param name : name of country
+ * @param name : name of country                 e.g. "U.S"
+ * @param iso2 : 2 char iso code                 e.g. "us"
+ * @param iso3 : 3 char iso code                 e.g. "usa"
+ * @param phoneCode : international dialing code e.g. 1
+ * @param length : length of the phone number without phone code
  */
 data class Country(val name: String, val iso2: String, val iso3: String, val phoneCode: String, val length: Int, val format:String, val sample:String, val icon:String = "") {
 

--- a/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/alerts/SlackAlerts.kt
+++ b/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/alerts/SlackAlerts.kt
@@ -14,7 +14,8 @@ import slatekit.results.builders.Outcomes
  */
 class SlackAlerts(
     override val identity: Identity,
-    override val settings: AlertSettings
+    override val settings: AlertSettings,
+    override val client: HttpRPC = HttpRPC()
 ) : AlertService() {
 
     private val baseUrl = "https://hooks.slack.com/services"

--- a/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/common/Sender.kt
+++ b/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/common/Sender.kt
@@ -9,6 +9,8 @@ import slatekit.results.builders.Outcomes
 
 interface Sender<T> {
 
+    val client:HttpRPC
+
     /**
      * Whether or not sending is enabled
      */
@@ -61,7 +63,7 @@ interface Sender<T> {
      * @param request: A prebuilt http request representing the send
      */
     suspend fun send(request: Request): Outcome<Response> {
-        return awaitHttpOutcome { HttpRPC().sendAsync(request, it) }
+        return awaitHttpOutcome { client.sendAsync(request, it) }
     }
 
     /**
@@ -69,7 +71,7 @@ interface Sender<T> {
      * @param request: A prebuilt http request representing the send
      */
     fun sendSync(request: Request): Outcome<Response> {
-        val response = HttpRPC().call(request)
+        val response = client.call(request)
         return response.toOutcome()
     }
 

--- a/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/email/EmailService.kt
+++ b/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/email/EmailService.kt
@@ -15,10 +15,14 @@ package slatekit.notifications.email
 
 import slatekit.common.templates.Templates
 import slatekit.common.types.Vars
+import slatekit.http.HttpRPC
 import slatekit.notifications.common.TemplateSender
 import slatekit.results.*
 
-abstract class EmailService(override val templates: Templates? = null) : TemplateSender<EmailMessage> {
+abstract class EmailService(
+    override val templates: Templates? = null,
+    override val client: HttpRPC = HttpRPC()
+) : TemplateSender<EmailMessage> {
 
     /**
      * Sends the email message

--- a/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/email/SendGrid.kt
+++ b/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/email/SendGrid.kt
@@ -27,9 +27,10 @@ class SendGrid(
     user: String,
     key: String,
     phone: String,
-    templates: Templates? = null
+    templates: Templates? = null,
+    client: HttpRPC = HttpRPC()
 ) :
-    EmailService(templates) {
+    EmailService(templates, client) {
 
     val settings = EmailSettings(user, key, phone)
     //private val baseUrlOld = "https://api.sendgrid.com/api/mail.send.json"

--- a/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/push/PushGoogle.kt
+++ b/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/push/PushGoogle.kt
@@ -81,7 +81,8 @@ import slatekit.results.builders.Outcomes
 open class PushGoogle(
     _key: String,
     val config: Conf,
-    val logs: Logs
+    val logs: Logs,
+    override val client: HttpRPC = HttpRPC()
 ) : Sender<PushMessage> {
 
     private val settings = PushSettings("", _key, "")

--- a/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/push/PushIOS.kt
+++ b/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/push/PushIOS.kt
@@ -14,10 +14,11 @@
 package slatekit.notifications.push
 
 import okhttp3.Request
+import slatekit.http.HttpRPC
 import slatekit.notifications.common.Sender
 import slatekit.results.Outcome
 
-class PushIOS : Sender<PushMessage> {
+class PushIOS(override val client: HttpRPC = HttpRPC()) : Sender<PushMessage> {
 
     override fun validate(model: PushMessage): Outcome<PushMessage> {
         TODO("not implemented") // To change body of created functions use File | Settings | File Templates.

--- a/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/sms/SmsService.kt
+++ b/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/sms/SmsService.kt
@@ -17,6 +17,7 @@ import slatekit.common.templates.Templates
 import slatekit.common.types.Countries
 import slatekit.common.types.Vars
 import slatekit.common.types.Country
+import slatekit.http.HttpRPC
 import slatekit.notifications.common.TemplateSender
 import slatekit.results.*
 
@@ -27,7 +28,8 @@ import slatekit.results.*
  */
 abstract class SmsService(
     override val templates: Templates? = null,
-    val countries:List<Country> = listOf(Countries.usa)
+    val countries:List<Country> = listOf(Countries.usa),
+    override val client: HttpRPC = HttpRPC()
 ) : TemplateSender<SmsMessage> {
 
     /**

--- a/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/sms/SmsService.kt
+++ b/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/sms/SmsService.kt
@@ -80,14 +80,7 @@ abstract class SmsService(
         // Case 3: Inputs valid so massage
         else {
             val country = countryLookup[finalIso]
-            val finalPhone = country?.let { c ->
-                if (!phone.startsWith(country.phoneCode)) {
-                    "${c.phoneCode}$phone"
-                } else {
-                    phone
-                }
-            }
-
+            val finalPhone = country?.normalize(phone)
             Success(finalPhone ?: phone)
         }
     }

--- a/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/sms/TwilioSms.kt
+++ b/src/lib/kotlin/slatekit-notifications/src/main/kotlin/slatekit/notifications/sms/TwilioSms.kt
@@ -44,9 +44,10 @@ class TwilioSms(
     password: String,
     phone: String,
     templates: Templates? = null,
-    countries: List<Country> = listOf(Countries.usa)
+    countries: List<Country> = listOf(Countries.usa),
+    client: HttpRPC = HttpRPC()
 ) :
-    SmsService(templates, countries) {
+    SmsService(templates, countries, client) {
     private val settings = SmsSettings(key, password, phone)
     private val baseUrl = "https://api.twilio.com/2010-04-01/Accounts/$key/Messages.json"
 

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/NotificationTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/NotificationTests.kt
@@ -6,8 +6,10 @@ import org.junit.Assert
 import org.junit.Test
 import slatekit.common.conf.Config
 import slatekit.common.info.ApiLogin
+import slatekit.common.types.Countries
 import slatekit.notifications.email.EmailMessage
 import slatekit.notifications.email.SendGrid
+import slatekit.notifications.sms.SmsMessage
 import slatekit.notifications.sms.TwilioSms
 import test.TestApp
 
@@ -24,6 +26,7 @@ class NotificationTests {
         val service = SendGrid(key)
         val req = service.build(EmailMessage("jl@dc.com", "Series 123", "The totality", true))
         runBlocking {
+            Assert.assertTrue(req.success)
             req.onSuccess {
                 Assert.assertEquals("https://api.sendgrid.com/v3/mail/send", it.url().toString())
                 Assert.assertEquals("POST", it.method())
@@ -38,14 +41,33 @@ class NotificationTests {
         }
     }
 
-    //@Test
+    @Test
     fun can_build_twilio() {
-        val conf = Config.of(TestApp::class.java, "usr://.slatekit/common/conf/sms.conf")
-        val key = conf.apiLogin("sms")
-        val service = TwilioSms(key)
-        runBlocking {
-            val req = service.send("Testing from kotlin", "us", "123456789")
-            println(req)
+        val key = ApiLogin("9876543210", "abc123", "9876543210", "dev", "test")
+        val india = Countries.find("in")!!
+        val service = TwilioSms(key, countries = listOf(Countries.usa, india))
+        val cases = listOf(
+                Pair(Countries.usa, "1234567890"),
+                Pair(india, "1234567890")
+        )
+        cases.forEach {info ->
+            val country = info.first
+            val destinationPhone = info.second
+            val req = service.build(SmsMessage("hello sms from unit-test", country.iso2, destinationPhone))
+            runBlocking {
+                Assert.assertTrue(req.success)
+                req.onSuccess {
+                    Assert.assertEquals("https://api.twilio.com/2010-04-01/Accounts/abc123/Messages.json", it.url().toString())
+                    Assert.assertEquals("POST", it.method())
+                    Assert.assertTrue(it.header("Authorization").isNotEmpty())
+
+                    val expected = """To=%2B${country.phoneCode}${destinationPhone}&From=9876543210&Body=hello%20sms%20from%20unit-test"""
+                    val buffer = Buffer()
+                    it.body()?.writeTo(buffer)
+                    val content = buffer.readUtf8()
+                    Assert.assertEquals(expected, content)
+                }
+            }
         }
     }
 }

--- a/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/NotificationTests.kt
+++ b/src/lib/kotlin/slatekit-tests/src/test/kotlin/test/core/NotificationTests.kt
@@ -70,4 +70,16 @@ class NotificationTests {
             }
         }
     }
+
+    //@Test
+    fun can_build_twilio2() {
+        val conf = Config.of(TestApp::class.java, "usr://.slatekit/common/conf/sms.conf")
+        val key = conf.apiLogin("sms")
+        val india = Countries.find("in")!!
+        val service = TwilioSms(key, countries = listOf(Countries.usa, india))
+        runBlocking {
+            val result = service.send("testing from unit-tests", Countries.usa.iso2, "1234567890")
+            println(result)
+        }
+    }
 }


### PR DESCRIPTION
## Overview
Misc small fixes for the **notifications** components ( Sms, Email, Email, Push )

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
n/a

## Design
1. Notifications: `HttpRPC` component is now injected in
2. Notifications: `HttpRPC` component is now a singleton
3. HttpRPC: The `OkHttpClient` can now be provided via a function builder and/or configured as a **singleton**

## Notes
n/a

## Pending
n/a

## Tests
1. Updated unit-tests for email/sms request building
