### PR TITLE
BUILD: Git Hub Packages in code generator + misc fixes

### DIFF
--- a/src/apps/kotlin/slatekit-samples/build.gradle
+++ b/src/apps/kotlin/slatekit-samples/build.gradle
@@ -1,11 +1,9 @@
-apply from: '../../../../build/gradle/slatekit-common.gradle'
-
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.72'
     ext.slatekit_version = new File('../version.txt').text
     ext.slatekit_version_beta = new File('../version-beta.txt').text
     ext.ktor_version = '1.1.1'
-    ext.logback_contrib_version = '0.1.5'
+    ext.logback_contrib_version ='1.2.3'
 
     repositories {
         jcenter()
@@ -13,15 +11,37 @@ buildscript {
     }
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.3"
     }
-
 }
 
-apply plugin: 'java'
-apply plugin: 'kotlin'
+plugins {
+    id "java"
+    id "maven-publish"
+    id "org.jetbrains.kotlin.jvm" // version "$kotlin_version"
+}
+
+apply from: '../../../../build/gradle/slatekit-common.gradle'
 apply plugin: 'application'
 
+compileJava {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+repositories {
+    jcenter()
+    mavenCentral()
+    maven {
+        url "https://maven.pkg.github.com/slatekit/slatekit"
+        credentials {
+            username = System.getenv('SLATEKIT_INSTALL_ACTOR')
+            password = System.getenv('SLATEKIT_INSTALL_TOKEN')
+        }
+    }
+}
+apply from: '../../../../build/gradle/slatekit-common.gradle'
+
+ext.slatekitSetupViaBinary = true //System.getenv('SLATEKIT_PROJECT_MODE') != 'sources'
 
 // ==================================================================
 // Slate Kit Component Info
@@ -35,7 +55,6 @@ def slatekitComponentVersion = ext.slatekit_version
 // ==================================================================
 // Slate Kit Setup mode: defaults to maven vs loading project sources
 // ==================================================================
-ext.slatekitSetupViaBinary = true //System.getenv('SLATEKIT_PROJECT_MODE') != 'sources'
 task info {
     println('slatekit.setup     : ' + System.getenv('SLATEKIT_PROJECT_MODE'))
     println('slatekit.maven     : ' + slatekitSetupViaBinary)
@@ -55,26 +74,6 @@ task info {
     println('build.date         : ' + getBuildDate())
 }
 
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-
-    kotlinOptions {
-        jvmTarget = '1.8'
-        apiVersion = '1.3'
-        languageVersion = '1.3'
-    }
-}
-
-
-repositories {
-    jcenter()
-    mavenCentral()
-    maven {
-        url  "https://dl.bintray.com/codehelixinc/slatekit"
-    }
-}
-
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
@@ -88,8 +87,9 @@ dependencies {
     compile "mysql:mysql-connector-java:5.1.13"
     compile 'com.squareup.okhttp3:okhttp:3.9.0'
     compile 'org.threeten:threetenbp:1.3.8'
-    compile "ch.qos.logback.contrib:logback-jackson:$logback_contrib_version"
-    compile "ch.qos.logback.contrib:logback-json-classic:$logback_contrib_version"
+    compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+    compile group: 'ch.qos.logback', name: 'logback-core'   , version: '1.2.3'
+    compile group: 'org.logback-extensions', name: 'logback-ext-loggly'   , version: '0.1.5'
     compile "com.fasterxml.jackson.core:jackson-databind:2.9.5"
     compile "org.slf4j:slf4j-api:1.7.25"
 

--- a/src/apps/kotlin/slatekit-samples/build.gradle
+++ b/src/apps/kotlin/slatekit-samples/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 plugins {
     id "java"
     id "maven-publish"
-    id "org.jetbrains.kotlin.jvm" // version "$kotlin_version"
+    id "org.jetbrains.kotlin.jvm" version "$kotlin_version"
 }
 
 apply from: '../../../../build/gradle/slatekit-common.gradle'
@@ -41,7 +41,7 @@ repositories {
 }
 apply from: '../../../../build/gradle/slatekit-common.gradle'
 
-ext.slatekitSetupViaBinary = true //System.getenv('SLATEKIT_PROJECT_MODE') != 'sources'
+ext.slatekitSetupViaBinary = false //System.getenv('SLATEKIT_PROJECT_MODE') != 'sources'
 
 // ==================================================================
 // Slate Kit Component Info

--- a/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/Sampler.kt
+++ b/src/apps/kotlin/slatekit-samples/src/main/kotlin/slatekit/samples/Sampler.kt
@@ -3,7 +3,8 @@ package slatekit.samples
 
 fun main(args: Array<String>) {
 //    Samples.app(args)
-      Samples.app(args)
+//      Samples.app(args)
+      Samples.cli(args)
 //    Samples.api(args)
 //    Samples.job(arrayOf("-sample=onetime"))
 }

--- a/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CLI.kt
+++ b/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CLI.kt
@@ -133,7 +133,6 @@ open class CLI(
      * Runs the shell continuously until "exit" or "quit" are entered.
      */
     private val lastArgs = AtomicReference<Args>(Args.empty())
-    private val REPL_MAX = 10
     suspend fun repl(): Try<Status> {
 
         // Keep reading from console until ( exit, quit ) is hit.

--- a/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CliUtils.kt
+++ b/src/lib/kotlin/slatekit-cli/src/main/kotlin/slatekit/cli/CliUtils.kt
@@ -16,6 +16,7 @@ package slatekit.cli
 import slatekit.common.args.Args
 import slatekit.common.info.Folders
 import slatekit.common.io.Files
+import slatekit.common.types.*
 import slatekit.results.*
 
 object CliUtils {

--- a/src/lib/kotlin/slatekit-common/build.gradle
+++ b/src/lib/kotlin/slatekit-common/build.gradle
@@ -20,6 +20,8 @@ plugins {
 
 apply from: '../../../../build/gradle/slatekit-common.gradle'
 
+sourceCompatibility = JavaVersion.VERSION_1_8
+
 compileJava {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8

--- a/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/writer/ConsoleWriter.kt
+++ b/src/lib/kotlin/slatekit-common/src/main/kotlin/slatekit/common/writer/ConsoleWriter.kt
@@ -54,10 +54,16 @@ class ConsoleWriter(
      */
     private fun write(color: String?, text: String, endLine: Boolean) {
         val finalColor = if(color == null || color == "") "" else "$color "
+        val resetText = "$finalColor$text$RESET"
         val finalText = if (endLine)
-            finalColor + text + newline
+            resetText + newline
         else
-            finalColor + text
+            resetText
         io.perform(finalText)
+    }
+
+    companion object {
+        const val ESCAPE = '\u001B'
+        const val RESET = "$ESCAPE[0m"
     }
 }

--- a/src/lib/kotlin/slatekit-generator/src/main/kotlin/slatekit/generator/Creator.kt
+++ b/src/lib/kotlin/slatekit-generator/src/main/kotlin/slatekit/generator/Creator.kt
@@ -3,16 +3,14 @@ package slatekit.generator
 import slatekit.context.Context
 import slatekit.common.io.Uris
 import slatekit.common.ext.toId
+import slatekit.common.log.Logger
 import slatekit.common.utils.Props
 import java.io.File
 
 /**
  * This processes all the [Action]s supported
  */
-class Creator(val context: Context, val ctx: GeneratorContext, val template: Template, val cls:Class<*>) {
-
-    val logger = context.logs.getLogger()
-
+class Creator(val context: Context, val ctx: GeneratorContext, val template: Template, val cls:Class<*>, val logger: Logger) {
 
     /**
      * Creates the directory after first interpreting the path.

--- a/src/lib/kotlin/slatekit-generator/src/main/kotlin/slatekit/generator/GeneratorResult.kt
+++ b/src/lib/kotlin/slatekit-generator/src/main/kotlin/slatekit/generator/GeneratorResult.kt
@@ -1,4 +1,4 @@
 package slatekit.generator
 
-data class GeneratorResult(val message:String, val output:String, val template:String) {
+data class GeneratorResult(val message:String, val output:String, val template:String, val logfile:String) {
 }

--- a/src/lib/kotlin/slatekit-generator/src/main/kotlin/slatekit/generator/ToolSettings.kt
+++ b/src/lib/kotlin/slatekit-generator/src/main/kotlin/slatekit/generator/ToolSettings.kt
@@ -6,7 +6,8 @@ package slatekit.generator
  */
 data class ToolSettings(
         val slatekitVersion:String,
-        val slatekitVersionBeta:String)
+        val slatekitVersionBeta:String,
+        val logFile:String)
 
 /**
  * Used for Kotlin related build settings

--- a/src/lib/kotlin/slatekit-tracking/src/main/kotlin/slatekit/tracking/Lasts.kt
+++ b/src/lib/kotlin/slatekit-tracking/src/main/kotlin/slatekit/tracking/Lasts.kt
@@ -59,13 +59,13 @@ open class Lasts<TRequest, TResponse, TFailure>(val id: Identity,
         getCustom(name)?.let { c -> c.set(Triple(sender, req, error)) }
     }
 
-    fun lastProcessed ():TRequest                  = _lastRequest.get()
-    fun lastSuccess   ():Triple<Any, TRequest, TResponse> = _lastSuccess.get()
-    fun lastInvalid   ():Triple<Any, TRequest, Failure<TFailure>> = _lastInvalid.get()
-    fun lastIgnored   ():Triple<Any, TRequest, Failure<TFailure>> = _lastIgnored.get()
-    fun lastDenied    ():Triple<Any, TRequest, Failure<TFailure>> = _lastDenied.get()
-    fun lastErrored   ():Triple<Any, TRequest, Failure<TFailure>> = _lastErrored.get()
-    fun lastUnexpected():Triple<Any, TRequest, Failure<TFailure>> = _lastUnexpected.get()
+    fun lastProcessed ():TRequest?                  = _lastRequest.get()
+    fun lastSuccess   ():Triple<Any, TRequest, TResponse>? = _lastSuccess.get()
+    fun lastInvalid   ():Triple<Any, TRequest, Failure<TFailure>>? = _lastInvalid.get()
+    fun lastIgnored   ():Triple<Any, TRequest, Failure<TFailure>>? = _lastIgnored.get()
+    fun lastDenied    ():Triple<Any, TRequest, Failure<TFailure>>? = _lastDenied.get()
+    fun lastErrored   ():Triple<Any, TRequest, Failure<TFailure>>? = _lastErrored.get()
+    fun lastUnexpected():Triple<Any, TRequest, Failure<TFailure>>? = _lastUnexpected.get()
     fun lastCustom(name:String):Triple<Any, TRequest, Failure<TFailure>>? = getCustom(name)?.get()
 
     fun clear(){

--- a/src/lib/kotlin/slatekit/build.gradle
+++ b/src/lib/kotlin/slatekit/build.gradle
@@ -114,7 +114,7 @@ dependencies {
     } //</slatekit_local>
 //    implementation project(":slatekit-examples")
 //    implementation project(":slatekit-samples")
-    implementation project(":slatekit-tests")
+//    implementation project(":slatekit-tests")
 }
 
 // ==================================================================

--- a/src/lib/kotlin/slatekit/settings.gradle
+++ b/src/lib/kotlin/slatekit/settings.gradle
@@ -96,5 +96,5 @@ project(':slatekit-connectors-jobs').projectDir=new File('../../../ext/kotlin/sl
 //include ':slatekit-samples'
 //project(':slatekit-samples').projectDir=new File('../../../apps/kotlin/slatekit-samples')
 //
-include ':slatekit-tests'
-project(':slatekit-tests').projectDir=new File('../slatekit-tests')
+//include ':slatekit-tests'
+//project(':slatekit-tests').projectDir=new File('../slatekit-tests')

--- a/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/SlateKitServices.kt
+++ b/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/SlateKitServices.kt
@@ -14,10 +14,11 @@ interface SlateKitServices {
 
     fun apis(settings:Conf): List<Api> {
         // APIs
-        val toolSettings = ToolSettings(settings.getString("slatekit.version"), settings.getString("slatekit.version.beta"))
+        val toolSettings = ToolSettings(settings.getString("slatekit.version"), settings.getString("slatekit.version.beta"), "logs/logback.log")
         val buildSettings = BuildSettings(settings.getString("kotlin.version"))
+        val logger = ctx.logs.getLogger("gen")
         return listOf(
-                Api(GeneratorApi(ctx, GeneratorService(ctx, settings, SlateKit::class.java, GeneratorSettings(toolSettings, buildSettings))), declaredOnly = true, setup = SetupType.Annotated),
+                Api(GeneratorApi(ctx, GeneratorService(ctx, settings, SlateKit::class.java, GeneratorSettings(toolSettings, buildSettings), logger = logger)), declaredOnly = true, setup = SetupType.Annotated),
                 Api(DocApi(ctx), declaredOnly = true, setup = SetupType.Annotated),
                 Api(CodeGenApi(), declaredOnly = true, setup = SetupType.Annotated)
         )

--- a/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/run.kt
+++ b/src/lib/kotlin/slatekit/src/main/kotlin/slatekit/run.kt
@@ -9,6 +9,7 @@ import slatekit.common.writer.ConsoleWriter
 import slatekit.context.AppContext
 import slatekit.context.Context
 import slatekit.generator.Help
+import slatekit.providers.logback.LogbackLogs
 import slatekit.results.Failure
 import slatekit.results.Success
 
@@ -94,7 +95,7 @@ fun run(args:Array<String>){
                 about = SlateKit.about,
                 schema = SlateKit.schema,
                 enc = SlateKit.encryptor,
-                logs = LogsDefault,
+                logs = LogbackLogs(),
                 hasAction = true,
                 source = Alias.Jar,
                 builder = { ctx -> SlateKit(ctx) }

--- a/src/lib/kotlin/slatekit/src/main/resources/env.conf
+++ b/src/lib/kotlin/slatekit/src/main/resources/env.conf
@@ -27,10 +27,10 @@ app.tags     = slate,shell,cli
 app.examples = sampleapp -env=dev -log.level=debug -region='ny' -enc=false
 
 slatekit.tag = "v2"
-slatekit.version = 2.3.0
-slatekit.version.beta = 2.3.0
-slatekit.version.cli = 2.3.0
-kotlin.version = 1.3.21
+slatekit.version = 2.4.5
+slatekit.version.beta = 2.4.5
+slatekit.version.cli = 2.4.5
+kotlin.version = 1.3.72
 generation.source = usr://slatekit/generator/templates
 generation.output = usr://slatekit/generator/gen
 templates.dir = /Users/kishore.reddy/dev/tmp/slatekit/slatekit/src/lib/kotlin/slatekit/src/main/resources/templates

--- a/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/api/files/build.txt
+++ b/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/api/files/build.txt
@@ -13,21 +13,27 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
-
 }
 
-apply plugin: 'java'
-apply plugin: 'kotlin'
-apply plugin:'application'
+plugins {
+    id "java"
+    id "application"
+    id "org.jetbrains.kotlin.jvm" version '${build.kotlin.version}'
+}
+
+
 mainClassName = "${app.package}.RunKt"
 sourceCompatibility = 1.8
-
 
 repositories {
     jcenter()
     mavenCentral()
     maven {
-        url  "https://dl.bintray.com/codehelixinc/slatekit"
+        url "https://maven.pkg.github.com/slatekit/slatekit"
+        credentials {
+            username = System.getenv('GITHUB_PACKAGES_INSTALL_ACTOR')
+            password = System.getenv('GITHUB_PACKAGES_INSTALL_TOKEN')
+        }
     }
 }
 

--- a/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/api/files/src/SampleModel.txt
+++ b/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/api/files/src/SampleModel.txt
@@ -1,8 +1,8 @@
 package ${app.package}.models
 
 import slatekit.common.DateTime
-import slatekit.entities.Id
-import slatekit.entities.Field
+import slatekit.meta.models.Id
+import slatekit.meta.models.Field
 
 data class SampleMovie(
         @property:Id()

--- a/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/app/files/build.txt
+++ b/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/app/files/build.txt
@@ -1,4 +1,3 @@
-
 buildscript {
     ext.kotlin_version = '${build.kotlin.version}'
     ext.slatekit_version = "${build.slatekit.version}"
@@ -11,22 +10,27 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
-
 }
 
-apply plugin: 'java'
-apply plugin: 'kotlin'
-apply plugin:'application'
+plugins {
+    id "java"
+    id "application"
+    id "org.jetbrains.kotlin.jvm" version '${build.kotlin.version}'
+}
+
 
 mainClassName = "${app.package}.RunKt"
 sourceCompatibility = 1.8
-
 
 repositories {
     jcenter()
     mavenCentral()
     maven {
-        url  "https://dl.bintray.com/codehelixinc/slatekit"
+        url "https://maven.pkg.github.com/slatekit/slatekit"
+        credentials {
+            username = System.getenv('GITHUB_PACKAGES_INSTALL_ACTOR')
+            password = System.getenv('GITHUB_PACKAGES_INSTALL_TOKEN')
+        }
     }
 }
 

--- a/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/cli/files/build.txt
+++ b/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/cli/files/build.txt
@@ -10,22 +10,27 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
-
 }
 
-apply plugin: 'java'
-apply plugin: 'kotlin'
-apply plugin:'application'
+plugins {
+    id "java"
+    id "application"
+    id "org.jetbrains.kotlin.jvm" version '${build.kotlin.version}'
+}
+
+
 mainClassName = "${app.package}.RunKt"
-
 sourceCompatibility = 1.8
-
 
 repositories {
     jcenter()
     mavenCentral()
     maven {
-        url  "https://dl.bintray.com/codehelixinc/slatekit"
+        url "https://maven.pkg.github.com/slatekit/slatekit"
+        credentials {
+            username = System.getenv('GITHUB_PACKAGES_INSTALL_ACTOR')
+            password = System.getenv('GITHUB_PACKAGES_INSTALL_TOKEN')
+        }
     }
 }
 
@@ -43,6 +48,8 @@ dependencies {
     // Slate Kit
     compile "com.slatekit:slatekit-results:$slatekit_version"
     compile "com.slatekit:slatekit-common:$slatekit_version"
+    compile "com.slatekit:slatekit-meta:$slatekit_version"
+    compile "com.slatekit:slatekit-entities:$slatekit_version"
     compile "com.slatekit:slatekit-app:$slatekit_version"
     compile "com.slatekit:slatekit-cli:$slatekit_version"
     compile "com.slatekit:slatekit-apis:$slatekit_version"

--- a/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/cli/files/src/CLI.txt
+++ b/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/cli/files/src/CLI.txt
@@ -5,7 +5,7 @@ import slatekit.apis.routes.Api
 import slatekit.apis.support.Authenticator
 import slatekit.cli.CliSettings
 import slatekit.context.Context
-import slatekit.common.types.Content
+import slatekit.common.types.*
 import slatekit.common.info.ApiKey
 import slatekit.common.types.ContentType
 import slatekit.connectors.cli.CliApi
@@ -57,11 +57,24 @@ class CLI(val ctx: Context) {
 
 
     private fun print(item:Any?, type:ContentType) : Content {
-        val text = Serialization.json().serialize(item)
-        val wrap = """{ "value" : $text }""".trimMargin()
-        val body = org.json.JSONObject(wrap)
-        val pretty = body.toString(4)
-        val content = Content.text(pretty)
-        return content
+        val serializer = when(type){
+            ContentTypeCsv -> Serialization.csv()
+            ContentTypeProp -> Serialization.props()
+            else -> Serialization.json()
+        }
+        val text = serializer.serialize(item)
+        return if(type == ContentTypeJson) {
+            val wrap = """{ "value" : $text }""".trimMargin()
+            val body = org.json.JSONObject(wrap)
+            val pretty = body.toString(4)
+            Content.text(pretty)
+        }
+        else {
+            when(type){
+                ContentTypeCsv -> Content.csv(text)
+                ContentTypeProp -> Content.prop(text)
+                else -> Content.text(text)
+            }
+        }
     }
 }

--- a/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/cli/files/src/SampleModel.txt
+++ b/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/cli/files/src/SampleModel.txt
@@ -1,8 +1,8 @@
 package ${app.package}.models
 
 import slatekit.common.DateTime
-import slatekit.entities.Id
-import slatekit.entities.Field
+import slatekit.meta.models.Id
+import slatekit.meta.models.Field
 
 data class SampleMovie(
         @property:Id()

--- a/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/job/files/build.txt
+++ b/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/job/files/build.txt
@@ -10,22 +10,27 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
-
 }
 
-apply plugin: 'java'
-apply plugin: 'kotlin'
-apply plugin:'application'
+plugins {
+    id "java"
+    id "application"
+    id "org.jetbrains.kotlin.jvm" version '${build.kotlin.version}'
+}
+
+
 mainClassName = "${app.package}.RunKt"
-
 sourceCompatibility = 1.8
-
 
 repositories {
     jcenter()
     mavenCentral()
     maven {
-        url  "https://dl.bintray.com/codehelixinc/slatekit"
+        url "https://maven.pkg.github.com/slatekit/slatekit"
+        credentials {
+            username = System.getenv('GITHUB_PACKAGES_INSTALL_ACTOR')
+            password = System.getenv('GITHUB_PACKAGES_INSTALL_TOKEN')
+        }
     }
 }
 

--- a/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/sql/files/build.txt
+++ b/src/lib/kotlin/slatekit/src/main/resources/templates/slatekit/sql/files/build.txt
@@ -10,22 +10,27 @@ buildscript {
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
-
 }
 
-apply plugin: 'java'
-apply plugin: 'kotlin'
-apply plugin:'application'
+plugins {
+    id "java"
+    id "application"
+    id "org.jetbrains.kotlin.jvm" version '${build.kotlin.version}'
+}
+
+
 mainClassName = "${app.package}.RunKt"
-
 sourceCompatibility = 1.8
-
 
 repositories {
     jcenter()
     mavenCentral()
     maven {
-        url  "https://dl.bintray.com/codehelixinc/slatekit"
+        url "https://maven.pkg.github.com/slatekit/slatekit"
+        credentials {
+            username = System.getenv('GITHUB_PACKAGES_INSTALL_ACTOR')
+            password = System.getenv('GITHUB_PACKAGES_INSTALL_TOKEN')
+        }
     }
 }
 


### PR DESCRIPTION
## Overview
Support for using Git Hub Packages in Code Generator + misc fixes ( see below )

## Ticket(s) 
n/a

## Links(s) 
n/a

## Dependencies
n/a

## Design
1. Console : Color printing reset 
2. Tracking: Metrics component for last value now supports null
3. CLI: Now supports specifying the output mode ( e.g. $output=`json | prop | csv` )
4. Tools: Logging for the CLI code generator cleaned up ( logs only to file not console )
5. Tools: CLI code generator output shows blurb about log file ( for more details )
6. Tools: Code generator slight improvements ( pluggable logger ) 
7. Tools: Template files for code generator now uses Git Hub Packages

## Notes
n/a

## Pending
n/a

## Tests
All passed locally ( have to include tests in github actions going forward - separate ticket )
